### PR TITLE
add: 必要gemのインストール（#15）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+# フォーム支援
+gem 'simple_form'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
@@ -55,13 +58,16 @@ group :development, :test do
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 
-  # 環境変数管理用
-  gem 'dotenv-rails'
+  # 環境変数の管理
+  gem 'dotenv-rails', groups: [:development, :test]
 end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # モデルファイルにスキーマ情報を自動追記
+  gem 'annotate'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
+    annotate (2.6.5)
+      activerecord (>= 2.3.0)
+      rake (>= 0.8.7)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.1)
@@ -308,6 +311,9 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simple_form (5.4.0)
+      actionpack (>= 7.0)
+      activemodel (>= 7.0)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -370,6 +376,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   brakeman
   bundler-audit
@@ -387,6 +394,7 @@ DEPENDENCIES
   rails (~> 8.1.1)
   rubocop-rails-omakase
   selenium-webdriver
+  simple_form
   solid_cable
   solid_cache
   solid_queue


### PR DESCRIPTION
## 概要
アプリケーションに必要な、主要Gemの導入を行いました。

## 実施内容
- Gemfile に以下のGemを追加
  - `simple_form`（フォームの生成支援）
  - `dotenv-rails`（環境変数の管理）
  - `pry-rails`（デバッグ用コンソール）
  - `annotate`（モデルファイルにスキーマ情報を自動追記）
- `bundle install` を実行してインストール
- Railsサーバーを起動して、Gem導入後の動作を確認（異常なし）

## 関連Issue
Close #15