### PR TITLE
fix: メモ削除ボタンを、編集フォーム展開時のみ表示する(#148)

### DIFF
--- a/app/assets/stylesheets/plans/components/_spot_block.scss
+++ b/app/assets/stylesheets/plans/components/_spot_block.scss
@@ -769,28 +769,59 @@ body.goal-point-visible .spot-block--last .spot-detail-wrap {
   margin: 0 40px;
 }
 
+/* ✅ 削除ボタン：デフォルト非表示 */
 .spot-block .spot-memo.spot-memo--pin .spot-memo__delete {
-  position: absolute;
-  top: 6px;
-  right: 25px;
+  display: none;
+}
 
-  transform: translateY(-35%);
+/* ✅ 削除ボタン：編集中（is-editing）時のみ表示、メモ枠の右側・縦中央、赤背景・白× */
+.spot-block .spot-memo.spot-memo--pin.is-editing .spot-memo__delete {
+  display: inline-flex;
+
+  position: absolute;
+  top: 50%;
+  right: 15px;
+  transform: translateY(-50%);
+
   z-index: 30;
 
-  border: 0;
-  background: transparent;
-  box-shadow: none;
+  width: 24px;
+  height: 24px;
 
-  color: rgba(0, 0, 0, 0.35);
-  font-size: 18px;
+  align-items: center;
+  justify-content: center;
+
+  border: 0;
+  border-radius: 9999px;
+
+  background: #dc3545;
+  box-shadow: 0 2px 6px rgba(220, 53, 69, 0.35);
+
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
   line-height: 1;
 
   padding: 0;
   cursor: pointer;
+
+  transition: background-color 0.12s, box-shadow 0.12s, transform 0.12s;
 }
 
-.spot-block .spot-memo.spot-memo--pin .spot-memo__delete:hover {
-  color: rgba(0, 0, 0, 0.55);
+.spot-block .spot-memo.spot-memo--pin.is-editing .spot-memo__delete:hover {
+  background: #c82333;
+  box-shadow: 0 3px 8px rgba(220, 53, 69, 0.45);
+  transform: translateY(-50%) scale(1.08);
+}
+
+.spot-block .spot-memo.spot-memo--pin.is-editing .spot-memo__delete:active {
+  transform: translateY(-50%) scale(0.96);
+  box-shadow: 0 1px 4px rgba(220, 53, 69, 0.3);
+}
+
+.spot-block .spot-memo.spot-memo--pin.is-editing .spot-memo__delete:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.35), 0 2px 6px rgba(220, 53, 69, 0.35);
 }
 
 /* -------------------------------

--- a/app/javascript/controllers/plan-spot-memo_controller.js
+++ b/app/javascript/controllers/plan-spot-memo_controller.js
@@ -55,7 +55,10 @@ export default class extends Controller {
     // ③ ✅ 既存メモは「表示したまま」にする（非表示にしない）
     // this.memoDisplayTarget.classList.add("d-none")
 
-    // ④ 初回フォーカス（末尾へ）
+    // ④ ✅ 編集中フラグ：削除ボタン表示用
+    this.memoDisplayTarget.classList.add("is-editing")
+
+    // ⑤ 初回フォーカス（末尾へ）
     window.setTimeout(() => this.focusTextareaToEnd(), 0)
   }
 
@@ -70,6 +73,9 @@ export default class extends Controller {
 
     // エディタ非表示
     this.editorTarget.classList.add("d-none")
+
+    // ✅ 編集中フラグ解除：削除ボタン非表示
+    this.memoDisplayTarget.classList.remove("is-editing")
 
     // 既存メモがあるなら再表示（※ open で隠さなくなったので実質そのまま）
     if (this.memoContentTarget?.innerText?.trim() !== "") {
@@ -93,6 +99,9 @@ export default class extends Controller {
       this.memoDisplayTarget.classList.add("d-none")
     }
 
+    // ✅ 編集中フラグ解除
+    this.memoDisplayTarget.classList.remove("is-editing")
+
     // エディタは閉じる
     this.editorTarget.classList.add("d-none")
   }
@@ -106,6 +115,8 @@ export default class extends Controller {
     this.textareaTarget.value = ""
     this.memoContentTarget.innerHTML = ""
     this.memoDisplayTarget.classList.add("d-none")
+    // ✅ 編集中フラグ解除
+    this.memoDisplayTarget.classList.remove("is-editing")
     this.editorTarget.classList.add("d-none")
   }
 

--- a/app/views/plans/form_components/_spot_block.html.erb
+++ b/app/views/plans/form_components/_spot_block.html.erb
@@ -40,9 +40,13 @@
         <%= render "plan_spots/tags/chips", plan: plan_spot.plan, plan_spot: plan_spot, tags: tags %>
       <% end %>
 
-      <%# ✅ 表示用メモ枠（削除ボタンあり） %>
+      <%# ✅ 表示用メモ枠（メモがある時だけ表示、削除ボタン付き） %>
       <div class="spot-memo spot-memo--pin <%= "d-none" if plan_spot.memo.blank? %>"
            data-plan-spot-memo-target="memoDisplay">
+
+        <div class="spot-memo__content" data-plan-spot-memo-target="memoContent">
+          <%= simple_format(h(plan_spot.memo.to_s)) %>
+        </div>
 
         <button type="button"
                 class="spot-memo__delete"
@@ -50,10 +54,6 @@
                 data-action="pointerdown->plan-spot-memo#stopPropagation click->plan-spot-memo#clear">
           ×
         </button>
-
-        <div class="spot-memo__content" data-plan-spot-memo-target="memoContent">
-          <%= simple_format(h(plan_spot.memo.to_s)) %>
-        </div>
       </div>
     </div>
   </div>
@@ -64,7 +64,7 @@
          data-plan-spot-memo-target="detail">
       <div class="spot-detail__inner">
 
-        <%# ✅ 編集用メモ枠（閉じる不具合修正版） %>
+        <%# ✅ 編集用メモ枠（削除ボタンは表示用メモ側にあるため、ここには置かない） %>
         <div class="spot-memo spot-memo--pin spot-memo--editor d-none"
              data-plan-spot-memo-target="editor"
              data-action="pointerdown->plan-spot-memo#stopPropagation click->plan-spot-memo#stopPropagation">


### PR DESCRIPTION
## 概要
表示用メモ（spot-memo--pin）に表示している削除ボタン（×）の出し分けと見た目を調整し、UIを意図した状態に揃えました。

## 実施内容
- メモ削除ボタン（×）を「表示用メモが描画される時のみ」DOMに出すように修正
- 削除ボタンを表示用メモ枠の右側・縦中央に配置
- 削除ボタンを赤い×ボタンとして視認性を改善

## 関連Issue
Close #148