### PR TITLE
refactor: start_pointsにmove_time/move_distance/move_cost/toll_usedを集約(#150)

### DIFF
--- a/db/migrate/20251222065404_move_route_metrics_from_goal_points_to_start_points.rb
+++ b/db/migrate/20251222065404_move_route_metrics_from_goal_points_to_start_points.rb
@@ -1,0 +1,52 @@
+# db/migrate/20251222065404_move_route_metrics_from_goal_points_to_start_points.rb
+class MoveRouteMetricsFromGoalPointsToStartPoints < ActiveRecord::Migration[8.1]
+  def up
+    # 1) start_points に追加（toll_used は既にある前提なので追加しない）
+    add_column :start_points, :move_time, :integer unless column_exists?(:start_points, :move_time)
+    add_column :start_points, :move_distance, :integer unless column_exists?(:start_points, :move_distance)
+    add_column :start_points, :move_cost, :integer unless column_exists?(:start_points, :move_cost)
+
+    # 2) 既存データがある場合に備えて goal_points → start_points へコピー
+    #    ※ start_points.toll_used は「カラムは既存」なので値だけ移す
+    execute <<~SQL.squish
+      UPDATE start_points
+      SET
+        move_time     = goal_points.move_time,
+        move_distance = goal_points.move_distance,
+        move_cost     = goal_points.move_cost,
+        toll_used     = goal_points.toll_used
+      FROM goal_points
+      WHERE start_points.plan_id = goal_points.plan_id
+    SQL
+
+    # 3) goal_points から削除（存在する場合のみ）
+    remove_column :goal_points, :move_time if column_exists?(:goal_points, :move_time)
+    remove_column :goal_points, :move_distance if column_exists?(:goal_points, :move_distance)
+    remove_column :goal_points, :move_cost if column_exists?(:goal_points, :move_cost)
+    remove_column :goal_points, :toll_used if column_exists?(:goal_points, :toll_used)
+  end
+
+  def down
+    # rollback 時：goal_points に戻す
+    add_column :goal_points, :move_time, :integer unless column_exists?(:goal_points, :move_time)
+    add_column :goal_points, :move_distance, :integer unless column_exists?(:goal_points, :move_distance)
+    add_column :goal_points, :move_cost, :integer unless column_exists?(:goal_points, :move_cost)
+    add_column :goal_points, :toll_used, :boolean unless column_exists?(:goal_points, :toll_used)
+
+    execute <<~SQL.squish
+      UPDATE goal_points
+      SET
+        move_time     = start_points.move_time,
+        move_distance = start_points.move_distance,
+        move_cost     = start_points.move_cost,
+        toll_used     = start_points.toll_used
+      FROM start_points
+      WHERE goal_points.plan_id = start_points.plan_id
+    SQL
+
+    remove_column :start_points, :move_time if column_exists?(:start_points, :move_time)
+    remove_column :start_points, :move_distance if column_exists?(:start_points, :move_distance)
+    remove_column :start_points, :move_cost if column_exists?(:start_points, :move_cost)
+    # toll_used は元から start_points にある前提なので down でも消さない
+  end
+end

--- a/db/migrate/20251222070046_change_move_distance_type_in_start_points.rb
+++ b/db/migrate/20251222070046_change_move_distance_type_in_start_points.rb
@@ -1,0 +1,10 @@
+# db/migrate/XXXXXXXXXXXXXX_change_move_distance_type_in_start_points.rb
+class ChangeMoveDistanceTypeInStartPoints < ActiveRecord::Migration[8.1]
+  def up
+    change_column :start_points, :move_distance, :float, using: "move_distance::double precision"
+  end
+
+  def down
+    change_column :start_points, :move_distance, :integer, using: "round(move_distance)::integer"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_19_045053) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_22_070046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -20,11 +20,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_19_045053) do
     t.datetime "created_at", null: false
     t.float "lat"
     t.float "lng"
-    t.integer "move_cost"
-    t.float "move_distance"
-    t.integer "move_time"
     t.bigint "plan_id", null: false
-    t.boolean "toll_used", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["plan_id"], name: "index_goal_points_on_plan_id"
   end
@@ -104,6 +100,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_19_045053) do
     t.datetime "departure_time"
     t.float "lat"
     t.float "lng"
+    t.integer "move_cost"
+    t.float "move_distance"
+    t.integer "move_time"
     t.bigint "plan_id", null: false
     t.string "prefecture"
     t.boolean "toll_used", default: false, null: false


### PR DESCRIPTION
## 目的
- 現状のUI（スタート→最初のスポット区間の移動情報を表示・編集）に対して、StartPoint側に保存先カラムが不足している状態を解消する
- GoalPointに存在していた「移動情報（距離・時間・料金・有料道路）」を、実際に責務が合うStartPointへ集約し、今後の再計算ロジック実装の前提を整える

## 作業項目
- StartPoint に以下のカラムを追加（GoalPointからの移行先）
  - move_time
  - move_distance（※floatへ修正）
  - move_cost
- GoalPoint から上記の不要カラムを削除（※既存データ/今後の拡張方針に合わせて削除）
- マイグレーション実行・schema.rb更新を確認

## 関連Issue
Close #150