### PR TITLE
feat: AI提案タブにChatGPT風ダミーUIを実装 (#180)

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -30,3 +30,4 @@
 @use "plans/components/map_search_box";
 @use "plans/components/infowindow";
 @use "plans/components/_start_departure_time";
+@use "plans/components/ai_suggestion_chat";

--- a/app/assets/stylesheets/plans/components/_ai_suggestion_chat.scss
+++ b/app/assets/stylesheets/plans/components/_ai_suggestion_chat.scss
@@ -1,0 +1,144 @@
+/* ==========================================
+   AI Suggestion Chat (ChatGPT風ダミーUI)
+========================================== */
+
+.ai-chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: #f7f7f8;
+}
+
+/* メッセージ一覧エリア */
+.ai-chat__messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* メッセージ行（左右寄せ共通） */
+.ai-chat__msg {
+  display: flex;
+  max-width: 85%;
+}
+
+/* AI側メッセージ（左寄せ） */
+.ai-chat__msg--assistant {
+  align-self: flex-start;
+}
+
+/* ユーザー側メッセージ（右寄せ） */
+.ai-chat__msg--user {
+  align-self: flex-end;
+}
+
+/* 吹き出し */
+.ai-chat__bubble {
+  padding: 12px 16px;
+  border-radius: 16px;
+  line-height: 1.6;
+  word-break: break-word;
+  font-size: 14px;
+}
+
+/* AI側の吹き出しスタイル */
+.ai-chat__msg--assistant .ai-chat__bubble {
+  background-color: #fff;
+  color: #333;
+  border: 1px solid #e5e5e5;
+  border-bottom-left-radius: 4px;
+}
+
+/* お知らせ用の吹き出し */
+.ai-chat__bubble--notice {
+  background-color: #fff8e6 !important;
+  border-color: #f0d58c !important;
+  color: #8a6d00 !important;
+  font-size: 13px;
+}
+
+/* ユーザー側の吹き出しスタイル */
+.ai-chat__msg--user .ai-chat__bubble {
+  background-color: #506d53;
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+
+/* 入力フォームエリア（下部固定風） */
+.ai-chat__composer {
+  flex-shrink: 0;
+  padding: 12px 16px 16px;
+  background-color: #fff;
+  border-top: 1px solid #e5e5e5;
+}
+
+.ai-chat__form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* テキストエリア */
+.ai-chat__input {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  font-size: 14px;
+  line-height: 1.5;
+  resize: none;
+  outline: none;
+
+  &:focus {
+    border-color: #506d53;
+    box-shadow: 0 0 0 2px rgba(80, 109, 83, 0.1);
+  }
+
+  &::placeholder {
+    color: #999;
+  }
+}
+
+/* ボタンエリア */
+.ai-chat__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* ボタン共通 */
+.ai-chat__btn {
+  padding: 8px 20px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  outline: none;
+}
+
+/* キャンセルボタン */
+.ai-chat__btn--cancel {
+  background-color: #f5f5f5;
+  color: #666;
+  border: 1px solid #d9d9d9;
+
+  &:hover {
+    background-color: #e8e8e8;
+  }
+}
+
+/* 送信ボタン（5px下げる） */
+.ai-chat__btn--send {
+  background-color: #506d53;
+  color: #fff;
+  border: 1px solid #506d53;
+  margin-top: 5px;
+
+  &:hover {
+    background-color: #3d5640;
+  }
+}

--- a/app/views/plans/form_components/_ai_suggestion_block.html.erb
+++ b/app/views/plans/form_components/_ai_suggestion_block.html.erb
@@ -1,1 +1,65 @@
-<div>AI提案タブの中身</div>
+<%# AI提案タブ: ChatGPT風ダミーUI（見た目のみ） %>
+
+<div class="ai-chat">
+  <%# メッセージ一覧エリア %>
+  <div class="ai-chat__messages">
+    <%# AI側: 未実装のお知らせ %>
+    <div class="ai-chat__msg ai-chat__msg--assistant">
+      <div class="ai-chat__bubble ai-chat__bubble--notice">
+        ※ AI機能は現在開発中です。<br>以下は会話イメージの例です。
+      </div>
+    </div>
+
+    <%# AI側: 案内文 %>
+    <div class="ai-chat__msg ai-chat__msg--assistant">
+      <div class="ai-chat__bubble">
+        こんにちは！ドライブプランのAIアシスタントです。<br>
+        出発地・行きたいエリア・所要時間などを教えてください。おすすめのルートをご提案します。
+      </div>
+    </div>
+
+    <%# ユーザー側: ダミーメッセージ %>
+    <div class="ai-chat__msg ai-chat__msg--user">
+      <div class="ai-chat__bubble">
+        栃木で日帰りドライブしたいです。朝9時に出発して、夕方までに帰りたいです。
+      </div>
+    </div>
+
+    <%# AI側: ダミー応答 %>
+    <div class="ai-chat__msg ai-chat__msg--assistant">
+      <div class="ai-chat__bubble">
+        栃木の日帰りドライブですね！<br><br>
+        以下のルートはいかがでしょうか？<br>
+        <strong>宇都宮 → 大谷資料館 → 日光東照宮 → いろは坂</strong><br><br>
+        所要時間は約7〜8時間を想定しています。途中でランチ休憩も取れますよ。<br>
+        もう少し詳しく教えていただけると、より具体的なプランをご提案できます。
+      </div>
+    </div>
+
+    <%# ユーザー側: ダミーメッセージ %>
+    <div class="ai-chat__msg ai-chat__msg--user">
+      <div class="ai-chat__bubble">
+        いいですね！大谷資料館は行ってみたいです。
+      </div>
+    </div>
+
+    <%# AI側: ダミー応答 %>
+    <div class="ai-chat__msg ai-chat__msg--assistant">
+      <div class="ai-chat__bubble">
+        大谷資料館は地下採掘場跡で、神秘的な空間が広がっています。<br>
+        プランに追加しますか？他にも気になるスポットがあればお知らせください。
+      </div>
+    </div>
+  </div>
+
+  <%# 入力フォーム（見た目のみ） %>
+  <div class="ai-chat__composer">
+    <form class="ai-chat__form" onsubmit="return false;">
+      <textarea class="ai-chat__input" placeholder="メッセージを入力..." rows="2"></textarea>
+      <div class="ai-chat__actions">
+        <button type="button" class="ai-chat__btn ai-chat__btn--cancel">キャンセル</button>
+        <button type="button" class="ai-chat__btn ai-chat__btn--send">送信</button>
+      </div>
+    </form>
+  </div>
+</div>


### PR DESCRIPTION
## 目的
AI提案タブにChatGPT風のダミーUIを実装します（見た目のみ、実機能なし）。

## 作業項目
- チャットUI（メッセージ一覧 + 入力フォーム）を実装
- AI側メッセージ（左寄せ）・ユーザー側メッセージ（右寄せ）の吹き出し
- 案内文とダミー会話（栃木ドライブの例）を表示
- 開発中のお知らせメッセージを一番上に追加
- 送信ボタン5px下げ対応

## 確認項目
- [ ] AI提案タブを開くとチャットUIが表示される
- [ ] AIとユーザーのメッセージが左右に分かれて見える
- [ ] メッセージ一覧がスクロール可能
- [ ] 下部に入力フォームがある
- [ ] 実機能（送信で通信・保存など）は発生しない

## 関連issue
Close #180