### PR TITLE
feat: プラン検索機能を追加（日本語タグ対応）#189

### DIFF
--- a/app/assets/stylesheets/plans/components/_plan_card.scss
+++ b/app/assets/stylesheets/plans/components/_plan_card.scss
@@ -7,6 +7,49 @@
   padding: 20px 16px 16px 16px;
 }
 
+.community-plans__search {
+  margin-bottom: 16px;
+}
+
+.community-plans__search-input-wrapper {
+  display: flex;
+  gap: 8px;
+}
+
+.community-plans__search-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  font-size: 14px;
+  outline: none;
+
+  &:focus {
+    border-color: #506d53;
+  }
+
+  &::placeholder {
+    color: #999;
+  }
+}
+
+.community-plans__search-button {
+  padding: 8px 12px;
+  background-color: #506d53;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+
+  &:hover {
+    background-color: darken(#506d53, 5%);
+  }
+
+  i {
+    font-size: 14px;
+  }
+}
+
 .community-plans__list {
   display: flex;
   flex-direction: column;

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -23,11 +23,14 @@ class PlansController < ApplicationController
       .publicly_visible
       .with_spots
       .where.not(id: @plan.id)
+      .search_keyword(params[:q])
       .includes(:user, :start_point, plan_spots: :spot)
       .preload(user: { user_spots: :tags })
       .order(updated_at: :desc)
       .page(params[:page])
       .per(5)
+
+    @search_query = params[:q]
   end
 
   def update

--- a/app/lib/google_place_types_dictionary.rb
+++ b/app/lib/google_place_types_dictionary.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Google Place Types の I18n 辞書を逆引きするモジュール
+# 日本語タグ名から英語キーを取得する（検索用）
+module GooglePlaceTypesDictionary
+  class << self
+    # 日本語の表示名から対応する英語キーの配列を返す
+    # 完全一致のみ対象（部分一致は行わない）
+    # 該当なしの場合は空配列を返す
+    def keys_for(query)
+      return [] if query.blank?
+
+      reverse_dictionary[query.to_s.strip] || []
+    end
+
+    private
+
+    # 日本語 => [英語キー, ...] の逆引き辞書をメモ化
+    def reverse_dictionary
+      @reverse_dictionary ||= build_reverse_dictionary
+    end
+
+    # I18n辞書から逆引き用ハッシュを構築
+    # 同じ日本語表記に複数の英語キーが対応する場合は配列にまとめる
+    def build_reverse_dictionary
+      result = Hash.new { |h, k| h[k] = [] }
+
+      translations = fetch_translations
+      return result if translations.blank?
+
+      translations.each do |english_key, japanese_value|
+        next if japanese_value.blank?
+
+        result[japanese_value.to_s] << english_key.to_s
+      end
+
+      result
+    end
+
+    # I18n辞書から google_place_types を取得
+    def fetch_translations
+      I18n.t("google_place_types", locale: :ja, default: {})
+    rescue StandardError
+      {}
+    end
+  end
+end

--- a/app/views/plans/form_components/_community_block.html.erb
+++ b/app/views/plans/form_components/_community_block.html.erb
@@ -2,6 +2,19 @@
 
 <%= turbo_frame_tag "community_plans" do %>
   <div class="community-plans">
+    <%# 検索フォーム %>
+    <div class="community-plans__search">
+      <form action="<%= edit_plan_path(@plan) %>" method="get" data-turbo-frame="community_plans">
+        <div class="community-plans__search-input-wrapper">
+          <%= text_field_tag :q, @search_query,
+                             placeholder: "プラン名・スポット・タグで検索",
+                             class: "community-plans__search-input" %>
+          <button type="submit" class="community-plans__search-button">
+            <i class="bi bi-search" aria-hidden="true"></i>
+          </button>
+        </div>
+      </form>
+    </div>
     <% if @community_plans.present? %>
       <div class="community-plans__list">
         <% @community_plans.each do |plan| %>
@@ -37,7 +50,11 @@
       <% end %>
     <% else %>
       <div class="community-plans__empty">
-        <p>まだ公開プランがありません</p>
+        <% if @search_query.present? %>
+          <p>「<%= @search_query %>」に一致するプランが見つかりませんでした</p>
+        <% else %>
+          <p>まだ公開プランがありません</p>
+        <% end %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## 目的
みんなのプランタブにキーワード検索機能を追加し、プラン名/スポット名/住所/タグで部分一致検索を可能にする。日本語タグ名（カフェ等）での検索にも対応。

## 変更内容
- `app/models/plan.rb`: `Plan.search_keyword(q)`スコープを追加
- `app/lib/google_place_types_dictionary.rb`: I18n辞書逆引きモジュールを新規作成
- `app/controllers/plans_controller.rb`: 検索パラメータの適用
- `app/views/plans/form_components/_community_block.html.erb`: 検索フォーム追加（Turbo Frame対応）
- `app/assets/stylesheets/plans/components/_plan_card.scss`: 検索フォームスタイル追加

## テスト内容
- 空検索 → 全件表示
- プラン名で検索 → 該当プランがヒット
- スポット名/住所で検索 → 該当プランがヒット
- 日本語タグ（カフェ等）で検索 → 対応するプランがヒット
- 英語タグ（cafe等）で検索 → 同様にヒット
- 存在しないワードで検索 → 0件表示（エラーなし）
- Turbo Frameでの検索がタブUIを壊さない

## 関連issue
close #189