### PR TITLE
feat: スポット未追加時の案内表示とUI改善 (#192)

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -32,3 +32,4 @@
 @use "plans/components/_start_departure_time";
 @use "plans/components/ai_suggestion_chat";
 @use "plans/components/plan_card";
+@use "plans/components/plan_tab_guide";

--- a/app/assets/stylesheets/plans/_plan_form.scss
+++ b/app/assets/stylesheets/plans/_plan_form.scss
@@ -114,7 +114,7 @@ body.no-footer {
 
     .plan-save {
       position: fixed;
-      bottom: calc(2rem + 5px); /* ✅ 5px下げる */
+      bottom: calc(2rem - 10px); /* ✅ 15px下げる */
       left: 58%;
       transform: translateX(-50%);
       z-index: 3;
@@ -168,7 +168,6 @@ body.no-footer {
         box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
         min-width: 320px;
         max-width: 90vw;
-        margin-bottom: 165px; /* 165px上に表示 */
       }
 
       &__message {
@@ -242,30 +241,31 @@ body.no-footer {
     }
 
     .plan-info {
-      position: fixed;
-      bottom: calc(2rem - 5px);
-      right: 2rem;
-      background: rgba(255, 255, 255, 0.95);
-      padding: 1rem 1.5rem;
-      border-radius: 10px;
-      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-      z-index: 3;
+      background: #f8f9fa;
+      border-top: 1px solid #e5e5e5;
+      padding: 16px 40px;
+      margin-top: 16px;
+
+      display: flex;
+      justify-content: center;
+      gap: 32px;
 
       &__row {
         display: flex;
-        justify-content: space-between;
-        gap: 15px;
+        align-items: center;
+        gap: 8px;
         margin: 0;
-        font-size: 0.9rem;
+        font-size: 14px;
         color: #333;
       }
 
       &__label {
         white-space: nowrap;
+        color: #666;
       }
 
       &__value {
-        text-align: right;
+        font-weight: 600;
         white-space: nowrap;
       }
     }

--- a/app/assets/stylesheets/plans/components/_plan_tab_guide.scss
+++ b/app/assets/stylesheets/plans/components/_plan_tab_guide.scss
@@ -1,0 +1,93 @@
+/* ==========================================
+   スポット未追加時の案内ブロック
+   start_point_block の直下に表示
+========================================== */
+
+.plan-tab-guide {
+  background: linear-gradient(135deg, #f8faf8 0%, #f0f4f0 100%);
+  border: 1px solid rgba(80, 109, 83, 0.2);
+  border-radius: 0;
+  padding: 20px 16px;
+  margin: 16px 0;
+}
+
+.plan-tab-guide__title {
+  margin: 8px 0 22px 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #506d53;
+  text-align: center;
+}
+
+.plan-tab-guide__steps {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.plan-tab-guide__step {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.plan-tab-guide__number {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  background: #506d53;
+  color: #fff;
+  border-radius: 50%;
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.plan-tab-guide__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-top: 2px;
+
+  strong {
+    font-size: 14px;
+    font-weight: 600;
+    color: #333;
+  }
+
+  span {
+    font-size: 13px;
+    color: #666;
+    line-height: 1.4;
+  }
+
+  i {
+    font-size: 12px;
+    color: #506d53;
+    margin: 0 2px;
+  }
+}
+
+.plan-tab-guide__privacy {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 23px;
+  padding-top: 21px;
+  border-top: 1px solid rgba(80, 109, 83, 0.15);
+
+  i {
+    font-size: 22px;
+    color: #506d53;
+  }
+
+  p {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 500;
+    color: #506d53;
+  }
+}

--- a/app/views/plans/_plan_form.html.erb
+++ b/app/views/plans/_plan_form.html.erb
@@ -35,13 +35,15 @@
     </button>
   </div>
 
-  <!-- プラン保存ボタン＋モーダル -->
-  <div class="plan-save" data-controller="plan-save-modal" data-plan-save-modal-plan-id-value="<%= plan.id %>">
-    <button type="button" class="btn btn-save" data-action="click->plan-save-modal#open">
-      プランを保存
-    </button>
+  <!-- プラン保存ボタン＋モーダル（コントローラは外側のラッパーに） -->
+  <div data-controller="plan-save-modal" data-plan-save-modal-plan-id-value="<%= plan.id %>">
+    <div class="plan-save">
+      <button type="button" class="btn btn-save" data-action="click->plan-save-modal#open">
+        プランを保存
+      </button>
+    </div>
 
-    <!-- 保存モーダル（オーバーレイ） -->
+    <!-- 保存モーダル（オーバーレイ）- transform影響を避けるためplan-saveの外に配置 -->
     <div class="plan-save-modal" data-plan-save-modal-target="modal" hidden>
       <div class="plan-save-modal__overlay" data-action="click->plan-save-modal#close"></div>
       <div class="plan-save-modal__dialog">
@@ -62,6 +64,4 @@
     </div>
   </div>
 
-  <!-- 右下: プラン情報 -->
-  <%= render "plans/form_components/plan_info", plan: plan %>
 </div>

--- a/app/views/plans/form_components/_plan_block.html.erb
+++ b/app/views/plans/form_components/_plan_block.html.erb
@@ -6,6 +6,11 @@
 
 <%= render "plans/form_components/start_point_block" %>
 
+<%# スポット未追加時のみ案内を表示 %>
+<% if @plan.plan_spots.empty? %>
+  <%= render "plans/form_components/plan_tab_guide" %>
+<% end %>
+
 <% spot_ids = @plan.plan_spots.select(:spot_id) %>
 
 <% user_spots_by_spot_id =
@@ -33,3 +38,6 @@
 
 <%# ✅ 帰宅地点は「スポットの有無」ではなく、トグル操作で表示/非表示を管理する %>
 <%= render "plans/form_components/goal_point_block", plan: @plan %>
+
+<%# ✅ 走行距離・移動時間 %>
+<%= render "plans/form_components/plan_info", plan: @plan %>

--- a/app/views/plans/form_components/_plan_info.html.erb
+++ b/app/views/plans/form_components/_plan_info.html.erb
@@ -1,17 +1,20 @@
-<div class="plan-info">
-  <p class="plan-info__row">
-    <span class="plan-info__label">走行距離</span>
-    <span class="plan-info__value"><%= plan.total_distance %>km</span>
-  </p>
-  <%# ✅ ETC料金は一旦非表示（料金取得ロジック未実装のため） %>
-  <%# if plan.has_toll_roads? %>
-    <%#= content_tag :p, class: "plan-info__row" do %>
-      <%#= content_tag :span, "ETC料金", class: "plan-info__label" %>
-      <%#= content_tag :span, "¥#{number_with_delimiter(plan.total_toll_cost)}", class: "plan-info__value" %>
+<%# スポットがある場合のみ表示 %>
+<% if plan.plan_spots.any? %>
+  <div class="plan-info">
+    <p class="plan-info__row">
+      <span class="plan-info__label">走行距離</span>
+      <span class="plan-info__value"><%= plan.total_distance %>km</span>
+    </p>
+    <%# ✅ ETC料金は一旦非表示（料金取得ロジック未実装のため） %>
+    <%# if plan.has_toll_roads? %>
+      <%#= content_tag :p, class: "plan-info__row" do %>
+        <%#= content_tag :span, "ETC料金", class: "plan-info__label" %>
+        <%#= content_tag :span, "¥#{number_with_delimiter(plan.total_toll_cost)}", class: "plan-info__value" %>
+      <%# end %>
     <%# end %>
-  <%# end %>
-  <p class="plan-info__row">
-    <span class="plan-info__label">移動時間</span>
-    <span class="plan-info__value"><%= plan.formatted_move_time %></span>
-  </p>
-</div>
+    <p class="plan-info__row">
+      <span class="plan-info__label">移動時間</span>
+      <span class="plan-info__value"><%= plan.formatted_move_time %></span>
+    </p>
+  </div>
+<% end %>

--- a/app/views/plans/form_components/_plan_tab_guide.html.erb
+++ b/app/views/plans/form_components/_plan_tab_guide.html.erb
@@ -1,0 +1,39 @@
+<%# ================================================================
+    スポット未追加時の案内パーシャル
+    用途: プランにスポットが0件のとき、操作方法を案内する
+================================================================ %>
+
+<div class="plan-tab-guide">
+  <p class="plan-tab-guide__title">スポットを追加してプランを作成しましょう</p>
+
+  <div class="plan-tab-guide__steps">
+    <div class="plan-tab-guide__step">
+      <span class="plan-tab-guide__number">1</span>
+      <div class="plan-tab-guide__text">
+        <strong>スポットを追加</strong>
+        <span>地図で検索、またはAI提案・みんなのプランから選択</span>
+      </div>
+    </div>
+
+    <div class="plan-tab-guide__step">
+      <span class="plan-tab-guide__number">2</span>
+      <div class="plan-tab-guide__text">
+        <strong>順番を調整</strong>
+        <span>スポットをドラッグして並び替え</span>
+      </div>
+    </div>
+
+    <div class="plan-tab-guide__step">
+      <span class="plan-tab-guide__number">3</span>
+      <div class="plan-tab-guide__text">
+        <strong>時間を設定</strong>
+        <span>右上の<i class="bi bi-clock"></i>から出発時間を設定</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="plan-tab-guide__privacy">
+    <i class="bi bi-shield-check"></i>
+    <p>出発場所・帰宅場所・メモは<br>他のユーザーには公開されません</p>
+  </div>
+</div>


### PR DESCRIPTION
## 目的
プランタブでスポットが未追加の場合に操作案内を表示し、ユーザーが迷わずプランを作成できるようにする。また、走行情報の表示位置を改善する。

## 変更内容
- `app/views/plans/form_components/_plan_tab_guide.html.erb`: 案内パーシャル新規作成（3ステップの操作説明 + プライバシー安心メッセージ）
- `app/assets/stylesheets/plans/components/_plan_tab_guide.scss`: 案内パーシャルのスタイル
- `app/views/plans/form_components/_plan_block.html.erb`: スポット0件時に案内を表示
- `app/views/plans/form_components/_plan_info.html.erb`: スポット0件時は走行情報を非表示に
- `app/views/plans/_plan_form.html.erb`: 走行情報をプランタブ内に移動、モーダル構造を修正
- `app/assets/stylesheets/plans/_plan_form.scss`: 走行情報のスタイル変更、モーダル中央配置、保存ボタン位置調整

## テスト内容
- スポット0件のプランを開く → 出発地点の直下に案内が表示される
- スポットを1件追加 → 案内が消え、走行情報が表示される
- スポットの並び替え → 従来通り動作する
- 帰宅地点トグル → 従来通り動作する
- プラン保存ボタン → モーダルが画面中央に表示される

## 関連issue
close #192