### PR TITLE
feat: みんなのプラン一覧画面を実装 (#67)

### DIFF
--- a/app/assets/stylesheets/plans/components/_plan_card.scss
+++ b/app/assets/stylesheets/plans/components/_plan_card.scss
@@ -7,6 +7,40 @@
   padding: 20px 16px 16px 16px;
 }
 
+.community-plans__page-title {
+  font-size: 35px;
+  color: var(--personal);
+  border-bottom: 2px solid var(--personal);
+  padding-bottom: 1rem;
+  margin-bottom: 2rem;
+  font-weight: bold;
+  text-align: center;
+}
+
+/* プラン一覧ページ用（2列グリッド） */
+.community-plans--index {
+  padding: 3rem 0 16px 0;
+
+  .community-plans__content {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 16px;
+  }
+
+  .community-plans__list {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+  }
+
+  /* モバイル時は1列に */
+  @media (max-width: 600px) {
+    .community-plans__list {
+      grid-template-columns: 1fr;
+    }
+  }
+}
+
 .community-plans__search {
   margin-bottom: 16px;
 }
@@ -127,8 +161,29 @@
   overflow: hidden;
 }
 
-.plan-card__favorite {
+.plan-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   flex-shrink: 0;
+}
+
+.plan-card__delete {
+  padding: 6px;
+  background: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #999;
+  font-size: 16px;
+  line-height: 1;
+
+  &:hover {
+    background: #e9ecef;
+  }
+}
+
+.plan-card__favorite {
   padding: 4px;
   background: none;
   border: none;

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -12,6 +12,16 @@ class Plan < ApplicationRecord
   scope :with_spots, -> { joins(:plan_spots).distinct }
   scope :publicly_visible, -> { joins(:user).where(users: { status: :active }) }
 
+  # みんなのプラン用のベースRelation（検索・includes・並び順を含む）
+  scope :for_community, ->(keyword: nil) {
+    publicly_visible
+      .with_spots
+      .search_keyword(keyword)
+      .includes(:user, :start_point, plan_spots: :spot)
+      .preload(user: { user_spots: :tags })
+      .order(updated_at: :desc)
+  }
+
   # キーワード検索（プラン名/スポット名/住所/タグで部分一致）
   # 日本語タグ名はI18n逆引きで英語キーに変換して検索
   scope :search_keyword, ->(q) {

--- a/app/views/plans/_plan_card.html.erb
+++ b/app/views/plans/_plan_card.html.erb
@@ -1,12 +1,22 @@
 <%# プランカード（一覧表示用の共通部品） %>
-<%# locals: plan_title:, spots: [], total_duration: nil, total_distance: nil, is_favorite: false %>
+<%# locals: plan_title:, spots: [], total_duration: nil, total_distance: nil, is_favorite: false, plan: nil, can_delete: false %>
 
 <div class="plan-card">
   <div class="plan-card__header">
     <h3 class="plan-card__title"><%= plan_title %></h3>
-    <button type="button" class="plan-card__favorite" aria-label="お気に入り">
-      <i class="bi <%= is_favorite ? 'bi-star-fill' : 'bi-star' %>" aria-hidden="true"></i>
-    </button>
+    <div class="plan-card__actions">
+      <button type="button" class="plan-card__favorite" aria-label="お気に入り">
+        <i class="bi <%= is_favorite ? 'bi-star-fill' : 'bi-star' %>" aria-hidden="true"></i>
+      </button>
+      <% if local_assigns[:can_delete] && local_assigns[:plan] %>
+        <%= button_to plan_path(plan), method: :delete,
+              class: "plan-card__delete",
+              aria: { label: "プランを削除" },
+              data: { turbo_confirm: "このプランを削除しますか？" } do %>
+          <i class="bi bi-trash" aria-hidden="true"></i>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 
   <% unique_tags = collect_unique_tags(spots) %>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -1,1 +1,66 @@
-<%= render "plan_card" %>
+<%# みんなのプラン一覧（plans#index） %>
+
+<div class="community-plans community-plans--index">
+  <h1 class="community-plans__page-title">みんなのプラン</h1>
+
+  <div class="community-plans__content">
+  <%# 検索フォーム %>
+  <div class="community-plans__search">
+    <%= form_with url: plans_path, method: :get, local: true do %>
+      <div class="community-plans__search-input-wrapper">
+        <%= text_field_tag :q, @search_query,
+                           placeholder: "プラン名・スポット・タグで検索",
+                           class: "community-plans__search-input" %>
+        <button type="submit" class="community-plans__search-button">
+          <i class="bi bi-search" aria-hidden="true"></i>
+        </button>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @plans.present? %>
+    <div class="community-plans__list">
+      <% @plans.each do |plan| %>
+        <%
+          # plan_spots を position 順で取得し、_plan_card 用のハッシュ形式に変換
+          spots_data = plan.plan_spots.sort_by(&:position).map do |ps|
+            spot = ps.spot
+            # ユーザーのuser_spotsからタグを取得
+            user_spot = plan.user.user_spots.find { |us| us.spot_id == spot.id }
+            tag_names = user_spot&.tags&.map { |tag| t("google_place_types.#{tag.tag_name}", default: tag.tag_name) } || []
+
+            {
+              name: spot.name,
+              address: spot.address,
+              tags: tag_names
+            }
+          end
+        %>
+        <%= render "plans/plan_card",
+                   plan_title: plan.title.presence || "無題のプラン",
+                   spots: spots_data,
+                   total_duration: plan.formatted_move_time,
+                   total_distance: "#{plan.total_distance}km",
+                   is_favorite: false,
+                   plan: plan,
+                   can_delete: current_user&.id == plan.user_id %>
+      <% end %>
+    </div>
+
+    <%# ページネーション %>
+    <% if @plans.total_pages > 1 %>
+      <div class="community-plans__pagination">
+        <%= paginate @plans %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="community-plans__empty">
+      <% if @search_query.present? %>
+        <p>「<%= @search_query %>」に一致するプランが見つかりませんでした</p>
+      <% else %>
+        <p>まだ公開プランがありません</p>
+      <% end %>
+    </div>
+  <% end %>
+  </div>
+</div>


### PR DESCRIPTION
## 目的
plans#index で「みんなのプラン一覧」を表示し、検索・削除機能を提供する

## 変更内容
- `app/models/plan.rb` - `Plan.for_community` スコープ追加（index/edit で共通利用）
- `app/controllers/plans_controller.rb` - index/destroy アクション実装
- `app/views/plans/index.html.erb` - 一覧画面（検索フォーム、カード一覧、ページネーション、空状態）
- `app/views/plans/_plan_card.html.erb` - 削除ボタン追加（can_delete, plan パラメータ対応）
- `app/assets/stylesheets/plans/components/_plan_card.scss` - ページタイトル、2列グリッド、削除ボタンのスタイル

## テスト内容
- /plans にアクセス → 公開プランがカードで2列表示される
- 検索欄にキーワードを入れて検索 → 一覧が絞り込まれる
- q 空で検索 → 一覧が全件に戻る
- 0件検索 → 0件メッセージが出て、エラーにならない
- 自分のプランにはゴミ箱アイコンが表示される
- ゴミ箱アイコンをクリック → 確認後削除される

## 関連issue
close #67