### PR TITLE
feat: 利用規約・プライバシーポリシー画面を追加 (#241)

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -21,6 +21,7 @@
 @use "pages/top_guest";
 @use "pages/top_user";
 @use "pages/mypage";
+@use "pages/legal";
 
 @use "plans/plan_form.scss";
 @use "plans/plan_entry";

--- a/app/assets/stylesheets/pages/_legal.scss
+++ b/app/assets/stylesheets/pages/_legal.scss
@@ -1,0 +1,131 @@
+/* ==========================================
+     pages/_legal.scss
+     利用規約・プライバシーポリシー
+========================================== */
+.legal-page {
+  background-color: var(--gray-bg, #f8f9fa);
+  min-height: 100vh;
+  padding: 3rem 1rem;
+}
+
+.legal-card {
+  background-color: #ffffff;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2.5rem 3rem;
+  border-radius: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.legal-title {
+  font-size: 1.75rem;
+  font-weight: bold;
+  color: var(--personal, #506d53);
+  text-align: center;
+  padding-bottom: 1rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 2px solid var(--personal, #506d53);
+}
+
+.legal-updated {
+  text-align: center;
+  color: #888;
+  font-size: 0.875rem;
+  margin-bottom: 2rem;
+}
+
+.legal-section {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #eee;
+
+  &:last-of-type {
+    border-bottom: none;
+    margin-bottom: 0;
+  }
+}
+
+.legal-section-title {
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: var(--personal, #506d53);
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  &::before {
+    content: "";
+    display: inline-block;
+    width: 4px;
+    height: 1.1rem;
+    background-color: var(--personal, #506d53);
+    border-radius: 2px;
+  }
+}
+
+.legal-section p,
+.legal-section ul {
+  color: #555;
+  line-height: 1.8;
+  font-size: 0.95rem;
+}
+
+.legal-section ul {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+
+  li {
+    margin-bottom: 0.5rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.legal-section strong {
+  color: #333;
+}
+
+.legal-highlight {
+  background-color: rgba(80, 109, 83, 0.08);
+  padding: 1rem;
+  border-radius: 8px;
+  border-left: 4px solid var(--personal, #506d53);
+  margin: 1rem 0;
+
+  p {
+    margin: 0;
+  }
+}
+
+.legal-back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: #ffffff;
+  color: var(--personal, #506d53);
+  border: 2px solid var(--personal, #506d53);
+  border-radius: 50px;
+  padding: 0.75rem 2rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background-color: var(--personal, #506d53);
+    color: #ffffff;
+  }
+}
+
+@media (max-width: 768px) {
+  .legal-card {
+    padding: 1.5rem;
+    margin: 0 0.5rem;
+  }
+
+  .legal-title {
+    font-size: 1.5rem;
+  }
+}

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,10 @@
 class StaticPagesController < ApplicationController
   def top
   end
+
+  def terms
+  end
+
+  def privacy
+  end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,10 @@
 <footer class="footer text-center text-muted py-3 mt-5 small">
   <div class="container">
+    <div class="mb-2">
+      <%= link_to "利用規約", terms_path, class: "text-muted text-decoration-none" %>
+      <span class="mx-2">|</span>
+      <%= link_to "プライバシーポリシー", privacy_path, class: "text-muted text-decoration-none" %>
+    </div>
     &copy; <%= Time.current.year %> DrivePeek. All rights reserved.
   </div>
 </footer>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,88 @@
+<div class="legal-page">
+  <div class="legal-card">
+    <h1 class="legal-title">プライバシーポリシー</h1>
+    <p class="legal-updated">最終更新日: <%= Date.today.strftime("%Y年%m月%d日") %></p>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">1. はじめに</h2>
+      <p>DrivePeek（以下「本サービス」といいます）は、ユーザーの皆様のプライバシーを尊重し、個人情報の保護に努めます。本プライバシーポリシーでは、本サービスにおける個人情報の取り扱いについて説明します。</p>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">2. 公開される情報について</h2>
+      <p>本サービスでは、作成したプランを他のユーザーと共有することができます。プランを公開した場合、以下の情報が他のユーザーに表示されます。</p>
+      <ul>
+        <li>プランのタイトル</li>
+        <li>プランに含まれるスポット情報</li>
+      </ul>
+      <div class="legal-highlight">
+        <p><strong>※ 出発地点・帰宅地点、メモ、ユーザー名は公開されません。</strong></p>
+      </div>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">3. 取得する情報</h2>
+      <p>本サービスでは、以下の情報を取得することがあります。</p>
+      <ul>
+        <li><strong>アカウント情報:</strong> メールアドレス、ユーザー名、パスワード（暗号化して保存）</li>
+        <li><strong>位置情報:</strong> プラン作成時に出発地点・帰宅地点を設定するために使用（ブラウザの許可が必要です）</li>
+        <li><strong>プランデータ:</strong> 作成したドライブプラン、追加したスポット、メモ等</li>
+        <li><strong>アクセス情報:</strong> IPアドレス、ブラウザ情報、アクセス日時等</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">4. 利用目的</h2>
+      <p>取得した情報は、以下の目的で利用します。</p>
+      <ul>
+        <li>本サービスの提供・運営</li>
+        <li>ユーザー認証・アカウント管理</li>
+        <li>ドライブプランの作成・保存・共有機能の提供</li>
+        <li>サービスの改善・新機能の開発</li>
+        <li>お問い合わせへの対応</li>
+        <li>不正利用の防止</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">5. 第三者提供</h2>
+      <p>本サービスは、以下の場合を除き、ユーザーの個人情報を第三者に提供することはありません。</p>
+      <ul>
+        <li>ユーザーの同意がある場合</li>
+        <li>法令に基づく場合</li>
+        <li>人の生命・身体・財産の保護のために必要な場合</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">6. 外部サービスの利用</h2>
+      <p>本サービスでは、以下の外部サービスを利用しています。これらのサービスにおける情報の取り扱いについては、各サービスのプライバシーポリシーをご確認ください。</p>
+      <ul>
+        <li><strong>Google Maps Platform:</strong> 地図表示、スポット検索、ルート計算に使用</li>
+        <li><strong>Anthropic Claude API:</strong> AIによるスポット提案機能に使用</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">7. Cookie・アクセス解析</h2>
+      <p>本サービスでは、ログイン状態の維持やサービス改善のためにCookieを使用しています。ブラウザの設定でCookieを無効にすることも可能ですが、一部の機能が正常に動作しなくなる場合があります。</p>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">8. プライバシーポリシーの変更</h2>
+      <p>本プライバシーポリシーは、必要に応じて変更することがあります。重要な変更がある場合は、本サービス上でお知らせします。</p>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">9. お問い合わせ</h2>
+      <p>本プライバシーポリシーに関するお問い合わせは、本サービスのお問い合わせフォームよりお願いいたします。</p>
+    </section>
+
+    <div class="text-center mt-4">
+      <%= link_to "/", class: "legal-back-btn" do %>
+        <i class="bi bi-arrow-left"></i>
+        トップページへ戻る
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,56 @@
+<div class="legal-page">
+  <div class="legal-card">
+    <h1 class="legal-title">利用規約</h1>
+    <p class="legal-updated">最終更新日: <%= Date.today.strftime("%Y年%m月%d日") %></p>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">第1条（適用）</h2>
+      <p>本規約は、DrivePeek（以下「本サービス」といいます）の利用条件を定めるものです。ユーザーの皆様には、本規約に従って本サービスをご利用いただきます。</p>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">第2条（サービス概要）</h2>
+      <p>本サービスは、ドライブプランの作成・共有を目的としたWebアプリケーションです。ユーザーは地図上でスポットを選択し、ドライブプランを作成・保存・共有することができます。</p>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">第3条（禁止事項）</h2>
+      <p>ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。</p>
+      <ul>
+        <li>法令または公序良俗に違反する行為</li>
+        <li>犯罪行為に関連する行為</li>
+        <li>本サービスの運営を妨害する行為</li>
+        <li>他のユーザーに迷惑をかける行為</li>
+        <li>他者の知的財産権、プライバシー権等を侵害する行為</li>
+        <li>不正アクセス、クローリング等の行為</li>
+        <li>その他、運営者が不適切と判断する行為</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">第4条（免責事項）</h2>
+      <ul>
+        <li>本サービスで提供される情報（ルート、所要時間、スポット情報等）は参考情報であり、正確性・完全性を保証するものではありません。</li>
+        <li>本サービスの利用により生じた損害について、運営者は一切の責任を負いません。</li>
+        <li>実際のドライブの際は、現地の交通状況や規制を必ずご確認ください。</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">第5条（サービスの変更・停止）</h2>
+      <p>運営者は、事前の通知なく本サービスの内容を変更、または提供を停止することがあります。これによりユーザーに生じた損害について、運営者は一切の責任を負いません。</p>
+    </section>
+
+    <section class="legal-section">
+      <h2 class="legal-section-title">第6条（規約の変更）</h2>
+      <p>運営者は、必要と判断した場合には、ユーザーに通知することなく本規約を変更することができます。変更後の利用規約は、本サービス上に掲載した時点から効力を生じるものとします。</p>
+    </section>
+
+    <div class="text-center mt-4">
+      <%= link_to "/", class: "legal-back-btn" do %>
+        <i class="bi bi-arrow-left"></i>
+        トップページへ戻る
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,4 +66,8 @@ Rails.application.routes.draw do
 
   # ヘルスチェック
   get "up" => "rails/health#show", as: :rails_health_check
+
+  # 静的ページ（利用規約・プライバシーポリシー）
+  get "terms" => "static_pages#terms", as: :terms
+  get "privacy" => "static_pages#privacy", as: :privacy
 end


### PR DESCRIPTION
## 概要

本リリースに向けて、サービスとして最低限必要な「利用規約」と「プライバシーポリシー」画面を作成しました。文面は暫定版で、後から編集しやすい構成になっています。

## 作業項目

- 利用規約ページ（`/terms`）を作成
- プライバシーポリシーページ（`/privacy`）を作成
- フッターに両ページへのリンクを追加
- 法的ページ用のスタイル（`_legal.scss`）を作成

## 変更ファイル

- `app/controllers/static_pages_controller.rb`: `terms`, `privacy` アクション追加
- `app/views/static_pages/terms.html.erb`: 利用規約ページ（新規）
- `app/views/static_pages/privacy.html.erb`: プライバシーポリシーページ（新規）
- `app/assets/stylesheets/pages/_legal.scss`: 法的ページ用スタイル（新規）
- `app/assets/stylesheets/application.bootstrap.scss`: スタイルのインポート追加
- `config/routes.rb`: `/terms`, `/privacy` ルート追加
- `app/views/shared/_footer.html.erb`: リンク追加

## 検証

### 手動テスト

- [x] `/terms` が正常に表示される
- [x] `/privacy` が正常に表示される
- [x] フッターから両ページにアクセスできる
- [x] ログイン前/後どちらからもアクセスできる
- [x] スマホ表示でも見やすい

### 自動テスト

```bash
bin/rails test
```

## 関連issue

close #241