### PR TITLE
feat: コミュニティタブのInfoWindowにプランに追加ボタンを表示

### DIFF
--- a/app/javascript/controllers/single_spot_preview_controller.js
+++ b/app/javascript/controllers/single_spot_preview_controller.js
@@ -100,6 +100,7 @@ export default class extends Controller {
           "vicinity",
           "geometry",
           "photos",
+          "types",
         ],
       },
       (place, status) => {
@@ -108,10 +109,13 @@ export default class extends Controller {
           return
         }
 
+        const buttonId = `dp-add-spot-preview-${place.place_id}`
+
         showInfoWindow({
           anchor: marker,
           place,
-          showButton: false,
+          buttonId,
+          showButton: true,
         })
       }
     )


### PR DESCRIPTION
## 概要
プラン編集画面のコミュニティタブで、プランカード・スポットカードのピンボタンクリック時に表示されるInfoWindowに「プランに追加」ボタンを表示するようにしました。

## 作業項目
- single_spot_preview_controllerで`showButton: true`に変更
- buttonIdを生成してshowInfoWindowに渡す
- typesフィールドを取得してspot:addイベントに含める

## 変更ファイル
- `app/javascript/controllers/single_spot_preview_controller.js`: showButton: true に変更、buttonId追加

## 検証
### 手動テスト
- [x] プラン編集画面のコミュニティタブでプランカードのスポット行をクリック
- [x] InfoWindowに「プランに追加」ボタンが表示される
- [x] ボタンクリックでスポットがプランに追加される
- [x] スポットカードのピンボタンでも同様に動作する

### 自動テスト
bin/rails test

## 関連issue
close #286