### PR TITLE
UserSpot の死にコードとテーブルを削除

### DIFF
--- a/app/controllers/api/plan_spots_controller.rb
+++ b/app/controllers/api/plan_spots_controller.rb
@@ -6,7 +6,6 @@ module Api
     def create
       result = SpotSetupService.new(
         plan: @plan,
-        user: current_user,
         spot_params: spot_params
       ).setup
 

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,7 +1,5 @@
 class Spot < ApplicationRecord
   # Associations
-  has_many :user_spots, dependent: :destroy
-  has_many :users, through: :user_spots
   has_many :like_spots, dependent: :destroy
   has_many :liked_by_users, through: :like_spots, source: :user
   has_many :plan_spots, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,6 @@ class User < ApplicationRecord
 
   # Associations
   has_many :plans, dependent: :destroy
-  has_many :user_spots, dependent: :destroy
-  has_many :spots, through: :user_spots
   has_many :like_spots, dependent: :destroy
   has_many :liked_spots, through: :like_spots, source: :spot
   has_many :like_plans, dependent: :destroy

--- a/app/models/user_spot.rb
+++ b/app/models/user_spot.rb
@@ -1,8 +1,0 @@
-class UserSpot < ApplicationRecord
-  # Associations
-  belongs_to :user
-  belongs_to :spot
-
-  # Validations
-  validates :user_id, uniqueness: { scope: :spot_id }
-end

--- a/app/services/spot_setup_service.rb
+++ b/app/services/spot_setup_service.rb
@@ -1,30 +1,27 @@
 class SpotSetupService
-  attr_reader :plan, :user, :spot_params
+  attr_reader :plan, :spot_params
 
-  Result = Struct.new(:success?, :spot, :plan_spot, :user_spot, :error_message, :errors, keyword_init: true)
+  Result = Struct.new(:success?, :spot, :plan_spot, :error_message, :errors, keyword_init: true)
 
-  def initialize(plan:, user:, spot_params:)
+  def initialize(plan:, spot_params:)
     @plan = plan
-    @user = user
     @spot_params = spot_params.to_h.with_indifferent_access
   end
 
-  # トランザクション内で Spot / PlanSpot / UserSpot を一貫して作成
+  # トランザクション内で Spot / PlanSpot を一貫して作成
   def setup
     spot = nil
     plan_spot = nil
-    user_spot = nil
 
     ActiveRecord::Base.transaction do
       spot = find_or_create_spot
       plan_spot = create_plan_spot(spot)
-      user_spot = find_or_create_user_spot(spot)
     end
 
     # ジャンル判定（トランザクション外で実行）
     spot.assign_genres_from_types(spot_params[:top_types])
 
-    Result.new(success?: true, spot: spot, plan_spot: plan_spot, user_spot: user_spot)
+    Result.new(success?: true, spot: spot, plan_spot: plan_spot)
   rescue ActiveRecord::RecordInvalid => e
     Result.new(success?: false, error_message: e.message, errors: e.record.errors.full_messages)
   rescue StandardError => e
@@ -44,9 +41,5 @@ class SpotSetupService
   def create_plan_spot(spot)
     # acts_as_list が末尾に自動追加
     plan.plan_spots.create!(spot: spot)
-  end
-
-  def find_or_create_user_spot(spot)
-    UserSpot.find_or_create_by!(user: user, spot: spot)
   end
 end

--- a/db/migrate/20260112061932_drop_user_spots.rb
+++ b/db/migrate/20260112061932_drop_user_spots.rb
@@ -1,0 +1,13 @@
+class DropUserSpots < ActiveRecord::Migration[8.1]
+  def change
+    drop_table :user_spots do |t|
+      t.bigint :user_id, null: false
+      t.bigint :spot_id, null: false
+      t.timestamps
+
+      t.index :user_id
+      t.index :spot_id
+      t.index [ :user_id, :spot_id ], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_06_135006) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_12_061932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -135,16 +135,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_135006) do
     t.index ["prefecture"], name: "index_start_points_on_prefecture"
   end
 
-  create_table "user_spots", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.bigint "spot_id", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.index ["spot_id"], name: "index_user_spots_on_spot_id"
-    t.index ["user_id", "spot_id"], name: "index_user_spots_on_user_id_and_spot_id", unique: true
-    t.index ["user_id"], name: "index_user_spots_on_user_id"
-  end
-
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -172,6 +162,4 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_135006) do
   add_foreign_key "spot_genres", "genres"
   add_foreign_key "spot_genres", "spots"
   add_foreign_key "start_points", "plans"
-  add_foreign_key "user_spots", "spots"
-  add_foreign_key "user_spots", "users"
 end

--- a/test/fixtures/user_spots.yml
+++ b/test/fixtures/user_spots.yml
@@ -1,9 +1,0 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  user: one
-  spot: one
-
-two:
-  user: two
-  spot: two

--- a/test/models/user_spot_test.rb
+++ b/test/models/user_spot_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class UserSpotTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
## 概要

使用されていない `UserSpot` モデルおよび `user_spots` テーブルを削除しました。
YAGNI原則に従い、死にコードを整理します。

## 作業項目

- `app/models/user_spot.rb` を削除
- `User` / `Spot` モデルから `user_spots` アソシエーションを削除
- `SpotSetupService` から `find_or_create_user_spot` メソッドを削除
- `user_spots` テーブルを削除するマイグレーションを追加
- 関連するテスト・フィクスチャを削除

## 変更ファイル

### 削除
- `app/models/user_spot.rb`
- `test/models/user_spot_test.rb`
- `test/fixtures/user_spots.yml`

### 変更
- `app/models/user.rb`: `has_many :user_spots` / `has_many :spots` 削除
- `app/models/spot.rb`: `has_many :user_spots` / `has_many :users` 削除
- `app/services/spot_setup_service.rb`: `user` パラメータと `find_or_create_user_spot` 削除
- `app/controllers/api/plan_spots_controller.rb`: `user:` パラメータ削除
- `test/services/spot_setup_service_test.rb`: `user:` パラメータ削除

### 追加
- `db/migrate/20260112061932_drop_user_spots.rb`

## 検証

### 手動テスト
- [x] スポット追加機能が正常に動作すること

### 自動テスト
```
bin/rails test
85 runs, 222 assertions, 0 failures, 0 errors, 0 skips
```

## 関連 Issue

close #296