### PR TITLE
feat: ハンバーガーメニューを5項目にシンプル化 (#291)

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,20 +16,10 @@
       <div class="sp__menu__nav">
         <ul id="menu__hamburger__nav" class="sp__menu__ul">
           <% if current_user.present? %>
-            <li>
-              <%= link_to authenticated_root_path, class: 'link-home' do %>
-                <i class="fas fa-house"></i> HOME
-              <% end %>
-            </li>
-            <% unless controller_name == 'plans' && action_name.in?(%w[edit]) %>
-              <li data-controller="create-plan-trigger">
-                <%= link_to "プランを作る", "#", data: { action: "click->create-plan-trigger#create" } %>
-              </li>
-            <% end %>
-            <li><%= link_to "みんなのドライブプラン", plans_path %></li>
-            <li><%= link_to "作ったドライブプラン", plans_my_plans_path %></li>
-            <li><%= link_to "お気に入りプラン", authenticated_root_path %></li>
-            <li><%= link_to "お気に入りスポット", authenticated_root_path %></li>
+            <li><%= link_to "プランを作る", new_plan_path %></li>
+            <li><%= link_to "みんなの旅", plans_path %></li>
+            <li><%= link_to "お気に入り", plans_path(favorites_only: 1) %></li>
+            <li><%= link_to "マイプラン", plans_my_plans_path %></li>
             <li><%= link_to "アカウント設定", account_profile_path %></li>
           <% else %>
             <li><%= link_to "TOP", unauthenticated_root_path %></li>


### PR DESCRIPTION
## 概要
ハンバーガーメニューを7項目から5項目にシンプル化し、ユーザー導線を向上。

## 作業項目
- HOME項目を削除
- 「みんなのドライブプラン」→「みんなの旅」に名称変更
- 「お気に入りプラン/スポット」を統合し「お気に入り」に
- 「作ったドライブプラン」→「マイプラン」に名称変更
- 「プランを作る」のリンク先を `/plans/new` に変更

## 変更ファイル
- `app/views/shared/_header.html.erb`: メニュー項目の整理

## 検証
### 手動テスト
- [ ] ハンバーガーメニューが5項目表示されること
- [ ] 「プランを作る」→ /plans/new に遷移すること
- [ ] 「みんなの旅」→ /plans に遷移すること
- [ ] 「お気に入り」→ お気に入りフィルター付きで表示されること
- [ ] 「マイプラン」→ 自分のプラン一覧に遷移すること

### 自動テスト
bin/rails test

## 関連issue
close #291