### PR TITLE
feat: ハンバーガーメニュー改善 & お気に入り専用ページ作成

### DIFF
--- a/app/assets/stylesheets/plans/components/_plan_card.scss
+++ b/app/assets/stylesheets/plans/components/_plan_card.scss
@@ -35,6 +35,8 @@
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 20px;
+    max-width: 850px;
+    margin: 0 auto;
   }
 
   /* モバイル時は1列に */
@@ -475,7 +477,7 @@
 .community-plans__list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
-  gap: 26px;
+  gap: 20px;
   max-width: 850px;
   margin: 0 auto;
 }
@@ -575,6 +577,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-width: 0;
   background-color: #fff;
   border: none;
   border-radius: 16px;

--- a/app/assets/stylesheets/shared/_footer.scss
+++ b/app/assets/stylesheets/shared/_footer.scss
@@ -2,6 +2,22 @@
      layouts/_footer.scss
      フッター用（必要なら使用）
 ========================================== */
+
+/* Sticky footer: フッターを常に画面下部に配置 */
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.main-content {
+  flex: 1;
+}
+
+footer.footer {
+  margin-top: auto;
+}
+
 /* フッターを非表示にするためのbodyクラス */
 body.no-footer footer.footer {
   display: none !important;

--- a/app/assets/stylesheets/shared/_header.scss
+++ b/app/assets/stylesheets/shared/_header.scss
@@ -121,33 +121,29 @@ body {
           font-size: 18px;
           color: #fff;
           text-decoration: none;
-          display: inline-block;
+          display: inline-grid;
+          grid-template-columns: 1.5em 7em;
+          align-items: center;
+          gap: 3px;
           letter-spacing: 1.3px;
           opacity: 0;
           transform: translate3d(0, 100%, 0);
           transition: all .3s cubic-bezier(0.25, 0.1, 0.25, 1);
 
-          &::before {
-            content: '';
-            position: absolute;
-            z-index: -1;
-            bottom: -3px;
-            left: 0;
-            width: 100%;
-            height: 2px;
-            background-color: #fff;
-            transform: scaleX(0);
-            transform-origin: 100% 0;
-            transition: transform 0.6s cubic-bezier(0.55, 0.05, 0.22, 0.99);
+          i {
+            text-align: center;
+          }
+
+          span {
+            text-align: center;
           }
 
           &.js-menu-open {
             opacity: 1;
             transform: translate3d(0,0,0);
 
-            &::before {
-              transform: scaleX(1);
-              transform-origin: 0 0;
+            &:hover {
+              opacity: 0.7;
             }
           }
         }

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,19 @@
+class FavoritesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @tab = params[:tab] == "spot" ? "spot" : "plan"
+
+    if @tab == "spot"
+      @spots = current_user.liked_spots
+        .includes(:genres)
+        .order(created_at: :desc)
+        .page(params[:page]).per(10)
+    else
+      @plans = current_user.liked_plans
+        .includes(:user, :start_point, :goal_point, plan_spots: { spot: :genres })
+        .order(created_at: :desc)
+        .page(params[:page]).per(10)
+    end
+  end
+end

--- a/app/views/account/profiles/show.html.erb
+++ b/app/views/account/profiles/show.html.erb
@@ -1,5 +1,5 @@
 <div class="mypage-container">
-  <h2 class="mypage-title">アカウント設定</h2>
+  <h2 class="mypage-title">設定</h2>
 
   <div class="mypage-card">
     <h3>アカウント情報</h3>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,82 @@
+<%# お気に入り一覧（favorites#index） %>
+
+<div class="community-plans community-plans--index">
+  <h1 class="community-plans__page-title">お気に入り</h1>
+
+  <div class="community-plans__content">
+    <%# タブ切り替え %>
+    <div class="community-plans__search">
+      <div class="community-plans__search-tabs">
+        <%= link_to favorites_path(tab: "plan"),
+                    class: "community-plans__search-tab #{'is-active' if @tab != 'spot'}" do %>
+          <span>プラン</span>
+        <% end %>
+        <%= link_to favorites_path(tab: "spot"),
+                    class: "community-plans__search-tab #{'is-active' if @tab == 'spot'}" do %>
+          <span>スポット</span>
+        <% end %>
+      </div>
+    </div>
+
+    <% if @tab == "spot" %>
+      <%# スポット一覧 %>
+      <% if @spots.present? %>
+        <% like_spots_map = LikeSpot.index_by_spot_id(user: current_user, spot_ids: @spots.map(&:id)) %>
+        <div class="community-plans__list">
+          <% @spots.each do |spot| %>
+            <%= render "plans/spot_card", spot: spot, like_spot: like_spots_map[spot.id] %>
+          <% end %>
+        </div>
+
+        <% if @spots.total_pages > 1 %>
+          <div class="community-plans__pagination">
+            <%= paginate @spots %>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="community-plans__empty">
+          <p>お気に入りスポットがありません</p>
+        </div>
+      <% end %>
+    <% else %>
+      <%# プラン一覧 %>
+      <% if @plans.present? %>
+        <% like_plans_map = LikePlan.index_by_plan_id(user: current_user, plan_ids: @plans.map(&:id)) %>
+        <div class="community-plans__list">
+          <% @plans.each do |plan| %>
+            <%
+              spots_data = plan.plan_spots.sort_by(&:position).map do |ps|
+                spot = ps.spot
+                {
+                  name: spot.name,
+                  address: spot.address,
+                  prefecture: spot.prefecture,
+                  city: spot.city
+                }
+              end
+              genre_names = plan.plan_spots.flat_map { |ps| ps.spot.genres.map(&:name) }.uniq
+            %>
+            <%= render "plans/plan_card",
+                       plan_title: plan.title.presence || "無題のプラン",
+                       spots: spots_data,
+                       genres: genre_names,
+                       total_duration: format_move_time(plan.spots_only_move_time),
+                       total_distance: "#{plan.spots_only_distance}km",
+                       plan: plan,
+                       like_plan: like_plans_map[plan.id] %>
+          <% end %>
+        </div>
+
+        <% if @plans.total_pages > 1 %>
+          <div class="community-plans__pagination">
+            <%= paginate @plans %>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="community-plans__empty">
+          <p>お気に入りプランがありません</p>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,15 +24,17 @@
   <body class="<%= content_for?(:body_class) ? yield(:body_class) : '' %>">
     <%= render 'shared/header' %>
 
-    <% if notice %>
-      <p class="alert alert-info"><%= notice %></p>
-    <% end %>
+    <main class="main-content">
+      <% if notice %>
+        <p class="alert alert-info"><%= notice %></p>
+      <% end %>
 
-    <% if alert %>
-      <p class="alert alert-danger"><%= alert %></p>
-    <% end %>
+      <% if alert %>
+        <p class="alert alert-danger"><%= alert %></p>
+      <% end %>
 
-    <%= yield %>
+      <%= yield %>
+    </main>
 
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/plans/my_plans/index.html.erb
+++ b/app/views/plans/my_plans/index.html.erb
@@ -1,7 +1,7 @@
-<%# 作ったドライブプラン一覧（plans/my_plans#index） %>
+<%# 作ったプラン一覧（plans/my_plans#index） %>
 
 <div class="community-plans community-plans--index">
-  <h1 class="community-plans__page-title">作ったドライブプラン</h1>
+  <h1 class="community-plans__page-title">作ったプラン</h1>
 
   <div class="community-plans__content">
   <%# 検索フォーム %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,6 +4,8 @@
       <%= link_to "利用規約", terms_path, class: "text-muted text-decoration-none" %>
       <span class="mx-2">|</span>
       <%= link_to "プライバシーポリシー", privacy_path, class: "text-muted text-decoration-none" %>
+      <span class="mx-2">|</span>
+      <%= link_to "お問い合わせ", "#", class: "text-muted text-decoration-none" %>
     </div>
     &copy; <%= Time.current.year %> DrivePeek. All rights reserved.
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,21 +16,11 @@
       <div class="sp__menu__nav">
         <ul id="menu__hamburger__nav" class="sp__menu__ul">
           <% if current_user.present? %>
-            <li>
-              <%= link_to authenticated_root_path, class: 'link-home' do %>
-                <i class="fas fa-house"></i> HOME
-              <% end %>
-            </li>
-            <% unless controller_name == 'plans' && action_name.in?(%w[edit]) %>
-              <li data-controller="create-plan-trigger">
-                <%= link_to "プランを作る", "#", data: { action: "click->create-plan-trigger#create" } %>
-              </li>
-            <% end %>
-            <li><%= link_to "みんなのドライブプラン", plans_path %></li>
-            <li><%= link_to "作ったドライブプラン", plans_my_plans_path %></li>
-            <li><%= link_to "お気に入りプラン", authenticated_root_path %></li>
-            <li><%= link_to "お気に入りスポット", authenticated_root_path %></li>
-            <li><%= link_to "アカウント設定", account_profile_path %></li>
+            <li><%= link_to new_plan_path do %><i class="fa-solid fa-pen"></i><span>プランを作る</span><% end %></li>
+            <li><%= link_to plans_path do %><i class="fa-solid fa-earth-asia"></i><span>みんなの旅</span><% end %></li>
+            <li><%= link_to favorites_path do %><i class="fa-solid fa-bookmark"></i><span>お気に入り</span><% end %></li>
+            <li><%= link_to plans_my_plans_path do %><i class="fa-solid fa-route"></i><span>作ったプラン</span><% end %></li>
+            <li><%= link_to account_profile_path do %><i class="fa-solid fa-gear"></i><span>設定</span><% end %></li>
           <% else %>
             <li><%= link_to "TOP", unauthenticated_root_path %></li>
             <li><%= link_to "新規登録", new_user_registration_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,9 @@ Rails.application.routes.draw do
   # スポット
   resources :spots, only: %i[show]
 
+  # お気に入り一覧
+  get "favorites" => "favorites#index"
+
   # お気に入りスポット
   resources :like_spots, only: %i[create destroy]
 


### PR DESCRIPTION
## 概要
ハンバーガーメニューを7項目から5項目に整理し、アイコン付きグリッドレイアウトに改善。
お気に入り専用ページを新規作成し、プラン/スポットのタブ切り替えに対応。
その他、プランカードの表示崩れ修正、Sticky footer実装などUI改善を実施。

## 作業項目
- ハンバーガーメニューを5項目に整理（プランを作る、みんなの旅、お気に入り、作ったプラン、設定）
- 各メニュー項目にアイコン追加（2カラムグリッドレイアウト）
- お気に入り専用ページ新規作成（FavoritesController, favorites/index.html.erb）
- プランカードの左右列幅不均等問題を修正（min-width: 0）
- Sticky footer実装（コンテンツが少なくてもフッターが画面下部に固定）
- フッターに「お問い合わせ」リンク追加
- 各ページタイトルをメニュー名と統一

## 変更ファイル
- `app/controllers/favorites_controller.rb`: 新規作成
- `app/views/favorites/index.html.erb`: 新規作成
- `config/routes.rb`: favorites ルート追加
- `app/views/shared/_header.html.erb`: メニュー5項目化、アイコン追加
- `app/assets/stylesheets/shared/_header.scss`: グリッドレイアウト、ホバー効果
- `app/views/shared/_footer.html.erb`: お問い合わせリンク追加
- `app/assets/stylesheets/shared/_footer.scss`: Sticky footer
- `app/views/layouts/application.html.erb`: main-contentラッパー追加
- `app/views/account/profiles/show.html.erb`: タイトル「設定」に変更
- `app/views/plans/my_plans/index.html.erb`: タイトル「作ったプラン」に変更
- `app/assets/stylesheets/plans/components/_plan_card.scss`: min-width: 0 追加

## 検証
### 手動テスト
- [x] ハンバーガーメニューの各リンクが正しい遷移先に移動する
- [x] お気に入りページでプラン/スポットタブ切り替えが動作する
- [x] プランカードが2列で均等幅表示される
- [x] コンテンツが少ないページでもフッターが画面下部に固定される
- [x] フッターの「お問い合わせ」リンクが表示される

### 自動テスト
bin/rails test

## 関連issue
close #291
close #301