### PR TITLE
Request Spec追加（API統合テスト）

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,8 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
+    # Deviseのルーティングを確実にロード
+    Rails.application.reload_routes!
   end
 
   config.around(:each) do |example|

--- a/spec/requests/api/ai_chats_spec.rb
+++ b/spec/requests/api/ai_chats_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::AiChats", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:plan) { create(:plan, user: user) }
+
+  before do
+    stub_google_geocoding_api
+    stub_google_directions_api
+    stub_openai_chat_api
+  end
+
+  describe "POST /api/ai_chats" do
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "AIチャットメッセージを送信する" do
+        expect {
+          post api_ai_chats_path, params: { plan_id: plan.id, message: "日光で温泉に行きたい" },
+               headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        }.to change(AiChatMessage, :count).by(2) # user + assistant
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "ユーザーメッセージとAIレスポンスが保存される" do
+        post api_ai_chats_path, params: { plan_id: plan.id, message: "テストメッセージ" },
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        messages = plan.ai_chat_messages.chronological
+        expect(messages.first.role).to eq("user")
+        expect(messages.first.content).to eq("テストメッセージ")
+        expect(messages.last.role).to eq("assistant")
+      end
+
+      it "空のメッセージは422を返す" do
+        post api_ai_chats_path, params: { plan_id: plan.id, message: "" },
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "Turbo Stream形式でレスポンスを返す" do
+        post api_ai_chats_path, params: { plan_id: plan.id, message: "テスト" },
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response.content_type).to include("text/vnd.turbo-stream.html")
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        post api_ai_chats_path, params: { plan_id: other_plan.id, message: "テスト" },
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        post api_ai_chats_path, params: { plan_id: plan.id, message: "テスト" }
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /api/ai_chats/destroy_all" do
+    before do
+      create(:ai_chat_message, :user_message, user: user, plan: plan)
+      create(:ai_chat_message, :assistant_conversation, user: user, plan: plan)
+    end
+
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "会話履歴を全削除する" do
+        expect {
+          delete destroy_all_api_ai_chats_path, params: { plan_id: plan.id },
+                 headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        }.to change { plan.ai_chat_messages.count }.from(2).to(0)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "Turbo Stream形式でレスポンスを返す" do
+        delete destroy_all_api_ai_chats_path, params: { plan_id: plan.id },
+               headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response.content_type).to include("text/vnd.turbo-stream.html")
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      before do
+        create(:ai_chat_message, :user_message, user: other_user, plan: other_plan)
+        sign_in user
+      end
+
+      it "404エラーを返す" do
+        delete destroy_all_api_ai_chats_path, params: { plan_id: other_plan.id },
+               headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "他人のメッセージは削除されない" do
+        expect {
+          delete destroy_all_api_ai_chats_path, params: { plan_id: other_plan.id },
+                 headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        }.not_to change { other_plan.ai_chat_messages.count }
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        delete destroy_all_api_ai_chats_path, params: { plan_id: plan.id }
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/api/goal_points_spec.rb
+++ b/spec/requests/api/goal_points_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::GoalPoints", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:plan) { create(:plan, user: user) }
+
+  before do
+    stub_google_geocoding_api
+    stub_google_directions_api
+  end
+
+  describe "PATCH /api/plans/:plan_id/goal_point" do
+    let(:goal_point_params) do
+      {
+        goal_point: {
+          lat: 35.6812,
+          lng: 139.7671,
+          address: "東京都千代田区"
+        }
+      }
+    end
+
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "帰宅地点を設定する" do
+        patch api_plan_goal_point_path(plan), params: goal_point_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(plan.reload.goal_point).to be_present
+        expect(plan.goal_point.address).to eq("東京都千代田区")
+      end
+
+      it "既存の帰宅地点を更新する" do
+        create(:goal_point, plan: plan, address: "旧住所")
+
+        patch api_plan_goal_point_path(plan), params: goal_point_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(plan.reload.goal_point.address).to eq("東京都千代田区")
+      end
+
+      it "座標情報を返す" do
+        patch api_plan_goal_point_path(plan), params: goal_point_params, as: :json
+
+        json = response.parsed_body
+        expect(json["lat"]).to eq(35.6812)
+        expect(json["lng"]).to eq(139.7671)
+        expect(json["address"]).to eq("東京都千代田区")
+      end
+
+      it "Turbo Stream形式でも動作する" do
+        patch api_plan_goal_point_path(plan),
+              params: goal_point_params,
+              headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include("text/vnd.turbo-stream.html")
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        patch api_plan_goal_point_path(other_plan), params: goal_point_params, as: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401エラーを返す" do
+        patch api_plan_goal_point_path(plan), params: goal_point_params, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/infowindows_spec.rb
+++ b/spec/requests/api/infowindows_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::Infowindows", type: :request do
+  let(:user) { create(:user) }
+  let(:plan) { create(:plan, user: user) }
+  let(:spot) { create(:spot) }
+
+  before do
+    stub_google_geocoding_api
+    stub_google_places_api
+  end
+
+  describe "GET /api/infowindow" do
+    context "ログイン済みの場合" do
+      before { sign_in user }
+
+      it "spot_idでInfoWindowを表示する" do
+        get api_infowindow_path, params: { spot_id: spot.id, plan_id: plan.id }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(spot.name)
+      end
+
+      it "place_idでInfoWindowを表示する" do
+        get api_infowindow_path, params: { place_id: "ChIJtest123", lat: 35.6580, lng: 139.7016 }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "edit_mode=start_pointで出発地点用UIを返す" do
+        create(:start_point, plan: plan, address: "東京都渋谷区")
+
+        get api_infowindow_path, params: { edit_mode: "start_point", plan_id: plan.id, name: "自宅" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("自宅")
+      end
+
+      it "edit_mode=goal_pointで帰宅地点用UIを返す" do
+        create(:goal_point, plan: plan, address: "東京都新宿区")
+
+        get api_infowindow_path, params: { edit_mode: "goal_point", plan_id: plan.id, name: "帰宅" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("帰宅")
+      end
+
+      it "プラン内のスポットの場合plan_spot_idを含む" do
+        plan_spot = create(:plan_spot, plan: plan, spot: spot)
+
+        get api_infowindow_path, params: { spot_id: spot.id, plan_id: plan.id }
+
+        expect(response).to have_http_status(:ok)
+        # プランに含まれているスポットの場合、削除ボタンが表示される
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ゲスト用UIを返す" do
+        get api_infowindow_path, params: { spot_id: spot.id }
+
+        expect(response).to have_http_status(:ok)
+        # ゲスト用UIはログインを促すメッセージを含む
+      end
+
+      it "認証不要でアクセス可能" do
+        get api_infowindow_path, params: { place_id: "ChIJtest123" }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "POST /api/infowindow" do
+    context "ログイン済みの場合" do
+      before { sign_in user }
+
+      it "InfoWindowを作成する" do
+        post api_infowindow_path, params: {
+          spot_id: spot.id,
+          plan_id: plan.id,
+          photo_urls: [ "https://example.com/photo1.jpg" ]
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(spot.name)
+      end
+
+      it "place_idで新規スポットを作成してInfoWindowを返す" do
+        post api_infowindow_path, params: {
+          place_id: "ChIJnew_place",
+          lat: 35.6580,
+          lng: 139.7016,
+          name: "新しいスポット",
+          address: "東京都渋谷区"
+        }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "button_labelを指定できる" do
+        post api_infowindow_path, params: {
+          spot_id: spot.id,
+          button_label: "プランに追加"
+        }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "show_button=falseでボタンを非表示にできる" do
+        post api_infowindow_path, params: {
+          spot_id: spot.id,
+          show_button: "false"
+        }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "認証エラーを返す" do
+        post api_infowindow_path, params: { spot_id: spot.id }
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/api/plan_spots/reorders_spec.rb
+++ b/spec/requests/api/plan_spots/reorders_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::PlanSpots::Reorders", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:plan) { create(:plan, user: user) }
+  let!(:spot1) { create(:spot) }
+  let!(:spot2) { create(:spot) }
+  let!(:spot3) { create(:spot) }
+  let!(:plan_spot1) { create(:plan_spot, plan: plan, spot: spot1, position: 1) }
+  let!(:plan_spot2) { create(:plan_spot, plan: plan, spot: spot2, position: 2) }
+  let!(:plan_spot3) { create(:plan_spot, plan: plan, spot: spot3, position: 3) }
+
+  before do
+    stub_google_geocoding_api
+    stub_google_directions_api
+  end
+
+  describe "PATCH /api/plans/:plan_id/plan_spots/reorder" do
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "スポットの順序を変更する" do
+        new_order = [ plan_spot3.id, plan_spot1.id, plan_spot2.id ]
+
+        patch reorder_api_plan_plan_spots_path(plan),
+              params: { ordered_plan_spot_ids: new_order },
+              as: :json
+
+        expect(response).to have_http_status(:no_content)
+
+        expect(plan_spot3.reload.position).to eq(1)
+        expect(plan_spot1.reload.position).to eq(2)
+        expect(plan_spot2.reload.position).to eq(3)
+      end
+
+      it "Turbo Stream形式でも動作する" do
+        new_order = [ plan_spot2.id, plan_spot3.id, plan_spot1.id ]
+
+        patch reorder_api_plan_plan_spots_path(plan),
+              params: { ordered_plan_spot_ids: new_order },
+              headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include("text/vnd.turbo-stream.html")
+      end
+
+      it "不正なIDは422を返す" do
+        patch reorder_api_plan_plan_spots_path(plan),
+              params: { ordered_plan_spot_ids: [ "invalid", "ids" ] },
+              as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "配列以外は422を返す" do
+        patch reorder_api_plan_plan_spots_path(plan),
+              params: { ordered_plan_spot_ids: "not_an_array" },
+              as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        patch reorder_api_plan_plan_spots_path(other_plan),
+              params: { ordered_plan_spot_ids: [ 1, 2, 3 ] },
+              as: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401エラーを返す" do
+        patch reorder_api_plan_plan_spots_path(plan),
+              params: { ordered_plan_spot_ids: [ plan_spot1.id ] },
+              as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/plan_spots_spec.rb
+++ b/spec/requests/api/plan_spots_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::PlanSpots", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:plan) { create(:plan, user: user) }
+  let(:spot) { create(:spot) }
+
+  before do
+    stub_google_geocoding_api
+    stub_google_directions_api
+  end
+
+  describe "POST /api/plans/:plan_id/plan_spots" do
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "スポットをプランに追加する" do
+        expect {
+          post api_plan_plan_spots_path(plan), params: { spot_id: spot.id }, as: :json
+        }.to change(PlanSpot, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+      end
+
+      it "追加されたplan_spotの情報を返す" do
+        post api_plan_plan_spots_path(plan), params: { spot_id: spot.id }, as: :json
+
+        json = response.parsed_body
+        expect(json["plan_spot_id"]).to be_present
+        expect(json["spot_id"]).to eq(spot.id)
+      end
+
+      it "存在しないスポットの場合404を返す" do
+        post api_plan_plan_spots_path(plan), params: { spot_id: 99999 }, as: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "Turbo Stream形式でも動作する" do
+        post api_plan_plan_spots_path(plan),
+             params: { spot_id: spot.id },
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include("text/vnd.turbo-stream.html")
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        post api_plan_plan_spots_path(other_plan), params: { spot_id: spot.id }, as: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401エラーを返す" do
+        post api_plan_plan_spots_path(plan), params: { spot_id: spot.id }, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "POST /api/plans/:plan_id/plan_spots/adopt" do
+    let!(:spot1) { create(:spot) }
+    let!(:spot2) { create(:spot) }
+    let!(:spot3) { create(:spot) }
+
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "複数スポットを一括追加する" do
+        spots_params = [
+          { spot_id: spot1.id },
+          { spot_id: spot2.id },
+          { spot_id: spot3.id }
+        ]
+
+        expect {
+          post adopt_api_plan_plan_spots_path(plan), params: { spots: spots_params }, as: :json
+        }.to change { plan.plan_spots.count }.by(3)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "既存スポットを置換する" do
+        existing_spot = create(:spot)
+        create(:plan_spot, plan: plan, spot: existing_spot)
+
+        spots_params = [
+          { spot_id: spot1.id },
+          { spot_id: spot2.id }
+        ]
+
+        post adopt_api_plan_plan_spots_path(plan), params: { spots: spots_params }, as: :json
+
+        expect(plan.reload.plan_spots.count).to eq(2)
+        expect(plan.plan_spots.pluck(:spot_id)).to match_array([ spot1.id, spot2.id ])
+      end
+
+      it "空のスポットリストは422を返す" do
+        post adopt_api_plan_plan_spots_path(plan), params: { spots: [] }, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "Turbo Stream形式でも動作する" do
+        spots_params = [ { spot_id: spot1.id } ]
+
+        post adopt_api_plan_plan_spots_path(plan),
+             params: { spots: spots_params },
+             headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        spots_params = [ { spot_id: spot1.id } ]
+
+        post adopt_api_plan_plan_spots_path(other_plan), params: { spots: spots_params }, as: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401エラーを返す" do
+        spots_params = [ { spot_id: spot1.id } ]
+
+        post adopt_api_plan_plan_spots_path(plan), params: { spots: spots_params }, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/start_points_spec.rb
+++ b/spec/requests/api/start_points_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::StartPoints", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:plan) { create(:plan, user: user) }
+
+  before do
+    stub_google_geocoding_api
+    stub_google_directions_api
+  end
+
+  describe "PATCH /api/plans/:plan_id/start_point" do
+    let(:start_point_params) do
+      {
+        start_point: {
+          lat: 35.6762,
+          lng: 139.6503,
+          address: "東京都渋谷区",
+          prefecture: "東京都",
+          city: "渋谷区"
+        }
+      }
+    end
+
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "出発地点を設定する" do
+        patch api_plan_start_point_path(plan), params: start_point_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(plan.reload.start_point).to be_present
+        expect(plan.start_point.address).to eq("東京都渋谷区")
+      end
+
+      it "既存の出発地点を更新する" do
+        create(:start_point, plan: plan, address: "旧住所")
+
+        patch api_plan_start_point_path(plan), params: start_point_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(plan.reload.start_point.address).to eq("東京都渋谷区")
+      end
+
+      it "toll_usedのみを更新できる" do
+        start_point = create(:start_point, plan: plan, toll_used: false)
+
+        patch api_plan_start_point_path(plan),
+              params: { start_point: { toll_used: true } },
+              as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(plan.reload.start_point.toll_used).to be true
+      end
+
+      it "toll_usedのみの更新時、start_pointが未設定なら422を返す" do
+        patch api_plan_start_point_path(plan),
+              params: { start_point: { toll_used: true } },
+              as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "Turbo Stream形式でも動作する" do
+        patch api_plan_start_point_path(plan),
+              params: start_point_params,
+              headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include("text/vnd.turbo-stream.html")
+      end
+
+      it "departure_timeを設定できる" do
+        params = {
+          start_point: {
+            lat: 35.6762,
+            lng: 139.6503,
+            address: "東京都渋谷区",
+            departure_time: "09:00"
+          }
+        }
+
+        patch api_plan_start_point_path(plan), params: params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(plan.reload.start_point.departure_time.strftime("%H:%M")).to eq("09:00")
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        patch api_plan_start_point_path(other_plan), params: start_point_params, as: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401エラーを返す" do
+        patch api_plan_start_point_path(plan), params: start_point_params, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/plan_spots_spec.rb
+++ b/spec/requests/plan_spots_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "PlanSpots", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:plan) { create(:plan, user: user) }
+  let(:spot) { create(:spot) }
+  let!(:plan_spot) { create(:plan_spot, plan: plan, spot: spot) }
+
+  before do
+    stub_google_geocoding_api
+    stub_google_directions_api
+  end
+
+  describe "DELETE /plans/:plan_id/plan_spots/:id" do
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "スポットをプランから削除する" do
+        expect {
+          delete plan_plan_spot_path(plan, plan_spot),
+                 headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        }.to change(PlanSpot, :count).by(-1)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "Turbo Stream形式でレスポンスを返す" do
+        delete plan_plan_spot_path(plan, plan_spot),
+               headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response.content_type).to include("text/vnd.turbo-stream.html")
+      end
+
+      it "HTML形式ではリダイレクトする" do
+        delete plan_plan_spot_path(plan, plan_spot)
+
+        expect(response).to redirect_to(edit_plan_path(plan))
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      let!(:other_plan_spot) { create(:plan_spot, plan: other_plan, spot: spot) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        delete plan_plan_spot_path(other_plan, other_plan_spot),
+               headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "スポットは削除されない" do
+        expect {
+          delete plan_plan_spot_path(other_plan, other_plan_spot),
+                 headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        }.not_to change(PlanSpot, :count)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        delete plan_plan_spot_path(plan, plan_spot)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it "スポットは削除されない" do
+        expect {
+          delete plan_plan_spot_path(plan, plan_spot)
+        }.not_to change(PlanSpot, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Plans", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  before do
+    stub_google_geocoding_api
+    stub_google_directions_api
+  end
+
+  describe "GET /plans" do
+    # for_communityスコープは2スポット以上のプランのみ表示
+    let!(:public_plan) { create(:plan, :with_spots, user: other_user, title: "公開プラン") }
+    let!(:no_spots_plan) { create(:plan, user: other_user, title: "スポットなしプラン") }
+
+    it "公開プラン一覧を表示する" do
+      get plans_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("公開プラン")
+      expect(response.body).not_to include("スポットなしプラン")
+    end
+
+    it "未ログインでもアクセス可能" do
+      get plans_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /plans/:id" do
+    context "公開プランの場合" do
+      let(:plan) { create(:plan, user: other_user) }
+
+      it "プラン詳細を表示する" do
+        get plan_path(plan)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "未ログインでもアクセス可能" do
+        get plan_path(plan)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "非公開プラン（ユーザーがhidden）の場合" do
+      let(:hidden_user) { create(:user, :hidden) }
+      let(:plan) { create(:plan, user: hidden_user) }
+
+      it "404エラーを返す" do
+        get plan_path(plan)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "GET /plans/new" do
+    context "ログイン済みの場合" do
+      before { sign_in user }
+
+      it "プラン作成画面を表示する" do
+        get new_plan_path
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        get new_plan_path
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "POST /plans" do
+    context "ログイン済みの場合" do
+      before { sign_in user }
+
+      it "プランを作成してedit画面にリダイレクトする" do
+        expect {
+          post plans_path, params: { lat: 35.6762, lng: 139.6503 }
+        }.to change(Plan, :count).by(1)
+
+        expect(response).to redirect_to(edit_plan_path(Plan.last))
+      end
+
+      it "作成されたプランはユーザーに紐づく" do
+        post plans_path, params: { lat: 35.6762, lng: 139.6503 }
+
+        expect(Plan.last.user).to eq(user)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        post plans_path, params: { lat: 35.6762, lng: 139.6503 }
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it "プランは作成されない" do
+        expect {
+          post plans_path, params: { lat: 35.6762, lng: 139.6503 }
+        }.not_to change(Plan, :count)
+      end
+    end
+  end
+
+  describe "GET /plans/:id/edit" do
+    let(:plan) { create(:plan, user: user) }
+
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "プラン編集画面を表示する" do
+        get edit_plan_path(plan)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        get edit_plan_path(other_plan)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        get edit_plan_path(plan)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "PATCH /plans/:id" do
+    let(:plan) { create(:plan, user: user, title: "元のタイトル") }
+
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "プランを更新する" do
+        patch plan_path(plan), params: { plan: { title: "新しいタイトル" } }
+
+        expect(response).to redirect_to(edit_plan_path(plan))
+        expect(plan.reload.title).to eq("新しいタイトル")
+      end
+
+      it "JSON形式で更新できる" do
+        patch plan_path(plan), params: { plan: { title: "JSONタイトル" } }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["success"]).to be true
+        expect(plan.reload.title).to eq("JSONタイトル")
+      end
+    end
+
+    context "他人のプランの場合" do
+      let(:other_plan) { create(:plan, user: other_user) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        patch plan_path(other_plan), params: { plan: { title: "変更" } }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        patch plan_path(plan), params: { plan: { title: "変更" } }
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /plans/:id" do
+    let!(:plan) { create(:plan, user: user) }
+
+    context "ログイン済み・自分のプランの場合" do
+      before { sign_in user }
+
+      it "プランを削除する" do
+        expect {
+          delete plan_path(plan)
+        }.to change(Plan, :count).by(-1)
+      end
+
+      it "削除後にリダイレクトする" do
+        delete plan_path(plan)
+
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "他人のプランの場合" do
+      let!(:other_plan) { create(:plan, user: other_user) }
+      before { sign_in user }
+
+      it "404エラーを返す" do
+        delete plan_path(other_plan)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "プランは削除されない" do
+        expect {
+          delete plan_path(other_plan)
+        }.not_to change(Plan, :count)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        delete plan_path(plan)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it "プランは削除されない" do
+        expect {
+          delete plan_path(plan)
+        }.not_to change(Plan, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Sessions", type: :request do
+  let(:user) { create(:user, email: "test@example.com", password: "password123") }
+
+  describe "GET /users/sign_in" do
+    it "ログイン画面を表示する" do
+      get new_user_session_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "ログイン済みの場合" do
+      before { sign_in user }
+
+      it "プラン作成画面にリダイレクトする" do
+        get new_user_session_path
+
+        expect(response).to redirect_to(new_plan_path)
+      end
+    end
+  end
+
+  describe "POST /users/sign_in" do
+    context "正しい認証情報の場合" do
+      it "ログインしてプラン作成画面にリダイレクトする" do
+        post user_session_path, params: {
+          user: { email: user.email, password: "password123" }
+        }
+
+        expect(response).to redirect_to(new_plan_path)
+      end
+
+      it "ログイン後はcurrent_userが設定される" do
+        post user_session_path, params: {
+          user: { email: user.email, password: "password123" }
+        }
+        follow_redirect!
+
+        expect(controller.current_user).to eq(user)
+      end
+    end
+
+    context "誤ったパスワードの場合" do
+      it "ログインに失敗する" do
+        post user_session_path, params: {
+          user: { email: user.email, password: "wrong_password" }
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "存在しないメールアドレスの場合" do
+      it "ログインに失敗する" do
+        post user_session_path, params: {
+          user: { email: "nonexistent@example.com", password: "password123" }
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "DELETE /users/sign_out" do
+    context "ログイン済みの場合" do
+      before { sign_in user }
+
+      it "ログアウトしてトップページにリダイレクトする" do
+        delete destroy_user_session_path
+
+        expect(response).to redirect_to(unauthenticated_root_path)
+      end
+
+      it "ログアウト後はcurrent_userがnilになる" do
+        delete destroy_user_session_path
+        follow_redirect!
+
+        expect(controller.current_user).to be_nil
+      end
+    end
+
+    context "未ログインの場合" do
+      it "トップページにリダイレクトする" do
+        delete destroy_user_session_path
+
+        expect(response).to redirect_to(unauthenticated_root_path)
+      end
+    end
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -2,7 +2,7 @@
 
 require "devise"
 
-# Devise mappingをテスト用に設定
+# Wardenテストモード有効化（Feature/System specs用）
 Warden.test_mode!
 
 RSpec.configure do |config|


### PR DESCRIPTION
## 概要
主要APIのRequest Specを追加し、コントローラ層の統合テストを整備。
全95件のRequest Specを追加（合計245テスト）。

## 作業項目
- Plans API（CRUD）テスト追加
- PlanSpots API（追加、削除、並び替え、adopt）テスト追加
- StartPoints / GoalPoints API テスト追加
- Infowindows API テスト追加
- AiChat API テスト追加
- Sessions（ログイン/ログアウト）テスト追加
- rails_helper.rb にルート初期化処理を集約
- spec/support/devise.rb の重複設定を整理

## 変更ファイル
- `spec/rails_helper.rb`: ルート初期化を before(:suite) に追加
- `spec/support/devise.rb`: 重複設定を削除
- `spec/requests/plans_spec.rb`: プランCRUDテスト（24件）
- `spec/requests/plan_spots_spec.rb`: スポット削除テスト（6件）
- `spec/requests/sessions_spec.rb`: 認証フローテスト（9件）
- `spec/requests/api/plan_spots_spec.rb`: スポット追加/adoptテスト（11件）
- `spec/requests/api/plan_spots/reorders_spec.rb`: 並び替えテスト（6件）
- `spec/requests/api/start_points_spec.rb`: 出発地点テスト（8件）
- `spec/requests/api/goal_points_spec.rb`: 帰宅地点テスト（7件）
- `spec/requests/api/ai_chats_spec.rb`: AIチャットテスト（11件）
- `spec/requests/api/infowindows_spec.rb`: InfoWindowテスト（13件）

## 検証
### 手動テスト
- [x] bundle exec rspec 全テスト通過（245 examples, 0 failures）
- [x] bundle exec rubocop オフェンスなし

### 自動テスト
bundle exec rspec

## 関連issue
close #355