### PR TITLE
feat: System Spec（E2Eテスト）を追加

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "capybara/rspec"
+require "selenium-webdriver"
+
+# ヘッドレスChromeドライバー設定
+Capybara.register_driver :selenium_chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless=new")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+  options.add_argument("--window-size=1400,900")
+  options.add_argument("--disable-gpu")
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.default_driver = :selenium_chrome_headless
+
+# タイムアウト設定
+Capybara.default_max_wait_time = 5
+
+# サーバー設定
+Capybara.server = :puma, { Silent: true }
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium_chrome_headless
+  end
+end

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Authentication", type: :system do
+  describe "ログイン画面" do
+    it "ログイン画面が表示される" do
+      visit new_user_session_path
+
+      expect(page).to have_content("ログイン")
+    end
+
+    it "ログイン方法選択が表示される" do
+      visit new_user_session_path
+
+      expect(page).to have_link("メールアドレスでログイン")
+    end
+
+    it "メールフォームに遷移できる" do
+      visit new_user_session_path(method: :email)
+
+      expect(page).to have_field("メールアドレス")
+      expect(page).to have_field("パスワード")
+      expect(page).to have_button("ログイン")
+    end
+  end
+
+  describe "新規登録画面" do
+    it "新規登録画面が表示される" do
+      visit new_user_registration_path
+
+      expect(page).to have_content("新規登録")
+    end
+
+    it "登録方法選択が表示される" do
+      visit new_user_registration_path
+
+      expect(page).to have_link("メールアドレスで登録")
+    end
+
+    it "メールフォームに遷移できる" do
+      visit new_user_registration_path(method: :email)
+
+      expect(page).to have_field("メールアドレス")
+      expect(page).to have_field("パスワード")
+      expect(page).to have_button("登録する")
+    end
+  end
+end

--- a/spec/system/community_spec.rb
+++ b/spec/system/community_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Community", type: :system do
+  before do
+    stub_google_geocoding_api
+    stub_google_directions_api
+  end
+
+  describe "みんなの旅一覧（未ログイン）" do
+    it "一覧ページが表示される" do
+      visit plans_path
+
+      expect(page).to have_content("みんなの旅")
+    end
+
+    it "検索フォームが表示される" do
+      visit plans_path
+
+      expect(page).to have_css(".list-page__sidebar")
+    end
+
+    it "プラン/スポット切り替えタブが表示される" do
+      visit plans_path
+
+      expect(page).to have_content("プラン")
+      expect(page).to have_content("スポット")
+    end
+  end
+end

--- a/spec/system/my_plans_spec.rb
+++ b/spec/system/my_plans_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "My Plans", type: :system do
+  describe "作ったプラン一覧" do
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        visit plans_my_plans_path
+
+        expect(page).to have_current_path(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/system/plan_creation_spec.rb
+++ b/spec/system/plan_creation_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Plan Creation", type: :system do
+  describe "新規プラン作成" do
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        visit new_plan_path
+
+        expect(page).to have_current_path(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/system/plan_editing_spec.rb
+++ b/spec/system/plan_editing_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Plan Editing", type: :system do
+  let!(:user) { create(:user) }
+  let!(:plan) { create(:plan, user: user) }
+
+  describe "プラン編集" do
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトする" do
+        visit edit_plan_path(plan)
+
+        expect(page).to have_current_path(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Static Pages", type: :system do
+  describe "トップページ（未ログイン）" do
+    it "トップページが表示される" do
+      visit unauthenticated_root_path
+
+      expect(page).to have_content("DrivePeek")
+    end
+  end
+
+  describe "利用規約" do
+    it "利用規約ページが表示される" do
+      visit terms_path
+
+      expect(page).to have_content("利用規約")
+    end
+  end
+
+  describe "プライバシーポリシー" do
+    it "プライバシーポリシーページが表示される" do
+      visit privacy_path
+
+      expect(page).to have_content("プライバシーポリシー")
+    end
+  end
+end


### PR DESCRIPTION
## 概要
System Spec（E2Eテスト）を追加しました。Capybara + Seleniumによるブラウザテストで、認証画面の表示確認、未ログイン時のリダイレクト確認、公開ページの表示確認をカバーしています。

## 作業項目
- Capybara/Selenium設定ファイルを追加
- 認証画面（ログイン/新規登録）のテストを追加
- 未ログイン時のリダイレクトテストを追加
- コミュニティ一覧ページのテストを追加
- 静的ページ（トップ、利用規約、プライバシーポリシー）のテストを追加

## 変更ファイル
- `spec/support/capybara.rb`: Capybara/Selenium設定
- `spec/system/authentication_spec.rb`: 認証画面テスト（6件）
- `spec/system/community_spec.rb`: コミュニティ一覧テスト（3件）
- `spec/system/my_plans_spec.rb`: マイプランリダイレクトテスト（1件）
- `spec/system/plan_creation_spec.rb`: プラン作成リダイレクトテスト（1件）
- `spec/system/plan_editing_spec.rb`: プラン編集リダイレクトテスト（1件）
- `spec/system/static_pages_spec.rb`: 静的ページテスト（3件）

## 検証
### 手動テスト
- [x] `bundle exec rspec spec/system/` で15件全てパス
- [x] `bundle exec rspec` で260件全てパス
- [x] 実行時間が7秒程度で高速

### 自動テスト
```bash
bundle exec rspec spec/system/
```

## 関連issue
close #356