### PR TITLE
UI微調整（検索ボックス配置・フラッシュメッセージ高さ） (#371)

### DIFF
--- a/app/assets/stylesheets/map/_map_search_box.scss
+++ b/app/assets/stylesheets/map/_map_search_box.scss
@@ -2,7 +2,7 @@
      地図上の検索ボックス
 ========================================== */
 .map-search-box {
-    position: absolute;
+    position: fixed;
     top: 10px;
     /* 地図の中央に配置（--navibar-slideを考慮して常に追従） */
     left: calc(

--- a/app/assets/stylesheets/mobile/_infowindow.scss
+++ b/app/assets/stylesheets/mobile/_infowindow.scss
@@ -223,6 +223,8 @@
       order: 2;
       padding: 0 65px;
       height: auto;
+      overflow: visible;
+      white-space: normal;
     }
 
     .dp-infowindow__genres {

--- a/app/assets/stylesheets/shared/_alerts.scss
+++ b/app/assets/stylesheets/shared/_alerts.scss
@@ -2,7 +2,7 @@
      components/_alerts.scss
      アラートメッセージ
 ========================================== */
-.alert {
+.dp-flash {
   position: fixed;
   top: 1rem;
   left: 50%;
@@ -10,33 +10,41 @@
   max-width: 600px;
   padding: 1rem 1.5rem;
   border-radius: 1rem;
-  background-color: rgba(255, 255, 255, 0.3);
+  background-color: #ffffff;
   color: inherit;
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-  z-index: 90;
+  z-index: 10001;
   text-align: center;
   border: 1px solid rgba(255, 255, 255, 0.4);
   font-weight: 500;
   transition: all 0.3s ease;
 }
 
-.alert.alert-info,
-.alert.alert-danger {
+.dp-flash--danger {
   background-color: #ffffff;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 12px;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
-  margin: 1.5rem auto;
-  opacity: 0.7;
 }
 
-.alert.alert-info {
-  margin-top: 5px;
-  left: 1.5rem;
-  transform: none;
-  text-align: left;
+/* モバイル: ハンバーガーメニューと同じ行に1行表示 */
+@media (max-width: 767px) {
+  .dp-flash {
+    top: 20px;
+    left: 12px;
+    right: 100px; /* ハンバーガー(right:24px + width:64px + gap:12px) */
+    transform: none;
+    max-width: none;
+    padding: 0 16px;
+    height: 44px;
+    line-height: 44px;
+    border-radius: 8px;
+    box-sizing: border-box;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    border: 1px solid #9a9a9a;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 14px;
+  }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,9 +31,9 @@
 
   <body class="<%= content_for?(:body_class) ? yield(:body_class) : '' %>">
     <%= render 'shared/header' unless content_for?(:hide_header) %>
+    <%= render "shared/flash" %>
 
     <main class="main-content">
-      <%= render "shared/flash" %>
       <%= yield %>
     </main>
 

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,11 +1,11 @@
 <%= turbo_frame_tag "flash" do %>
   <% if notice.present? %>
-    <div class="alert" data-controller="flash">
+    <div class="dp-flash" data-controller="flash">
       <%= notice %>
     </div>
   <% end %>
   <% if alert.present? %>
-    <div class="alert alert-danger" data-controller="flash">
+    <div class="dp-flash dp-flash--danger" data-controller="flash">
       <%= alert %>
     </div>
   <% end %>


### PR DESCRIPTION
## 概要
地図画面の検索ボックスを固定配置に変更し、フラッシュメッセージのBootstrapクラス衝突を解消。モバイルInfoWindowの住所表示切れも修正。

## 作業項目
- 地図内検索ボックスを `position: absolute` → `position: fixed` に変更
- フラッシュメッセージのクラス名を `.alert` → `.dp-flash` に変更しBootstrapとの衝突を解消
- フラッシュメッセージの `z-index` を最前面に変更（モーダル暗転の上に表示）
- フラッシュメッセージを `<main>` 外の `<body>` 直下に移動
- モバイル時のフラッシュメッセージをハンバーガーメニューと同じ行に配置
- モバイルInfoWindowの住所行の下部切れを修正

## 変更ファイル
- `app/assets/stylesheets/map/_map_search_box.scss`: `position: absolute` → `fixed`
- `app/assets/stylesheets/shared/_alerts.scss`: `.alert` → `.dp-flash` にリネーム、z-index・背景色・モバイル配置を修正
- `app/assets/stylesheets/mobile/_infowindow.scss`: 住所行に `overflow: visible; white-space: normal` 追加
- `app/views/shared/_flash.html.erb`: クラス名を `dp-flash` / `dp-flash--danger` に変更
- `app/views/layouts/application.html.erb`: フラッシュメッセージを `<main>` 外に移動

## 検証
### 手動テスト
- [ ] モバイル時にフラッシュメッセージがハンバーガーメニューと被らず横並びで表示される
- [ ] プラン作成エントリー画面（暗転モーダル）でフラッシュメッセージが最前面に表示される
- [ ] モバイルInfoWindowで住所の下部が切れずに表示される
- [ ] デスクトップで検索ボックスがスクロールしても固定位置に表示される

### 自動テスト
bin/rails test

## 関連issue
close #371