### PR TITLE
fix: モバイルInfoWindowコメントフッターの二重線・二重表示を修正 (#371)

### DIFF
--- a/app/assets/stylesheets/mobile/_infowindow.scss
+++ b/app/assets/stylesheets/mobile/_infowindow.scss
@@ -315,6 +315,15 @@
   padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
 }
 
+.mobile-infowindow__footer .dp-infowindow__comment-footer {
+  border-top: none;
+}
+
+/* コメントフッターはシート直下に移動されるため、元の位置の空divを非表示 */
+.mobile-infowindow__content .dp-infowindow__comment-footer {
+  display: none;
+}
+
 /* ボディスクロール防止 */
 body.mobile-infowindow-open {
   overflow: hidden;

--- a/app/javascript/controllers/mobile_infowindow_controller.js
+++ b/app/javascript/controllers/mobile_infowindow_controller.js
@@ -56,6 +56,13 @@ export default class extends Controller {
     const { html } = event.detail || {}
     if (!html) return
 
+    // 前回の残りをクリア（Turboキャッシュ復元対策）
+    const footerEl = document.getElementById("mobile-infowindow-footer")
+    if (footerEl) {
+      footerEl.innerHTML = ""
+      footerEl.hidden = true
+    }
+
     // コンテンツを挿入
     const contentEl = document.getElementById("mobile-infowindow-content")
     if (contentEl) {


### PR DESCRIPTION
## 概要
モバイルInfoWindowのコメントフッター周りで発生していた3つの不具合を修正。
コメントフッターの二重ボーダー線、Turboキャッシュ復元時のコメント入力欄二重表示、
`appendChild`後に残る空divのボーダーちらつきを解消。

## 作業項目
- コメントフッターの二重ボーダー線を解消（外側border-topのみ残し内側をnoneに）
- `appendChild`後の空div非表示CSS追加
- `show()`冒頭でフッタークリア処理を追加（Turboキャッシュ復元対策）

## 変更ファイル
- `app/assets/stylesheets/mobile/_infowindow.scss`: フッター内コメントフッターのborder-top除去、元位置の空div非表示
- `app/javascript/controllers/mobile_infowindow_controller.js`: show()冒頭でフッターをクリア

## 検証
### 手動テスト
- [ ] モバイルでスポットInfoWindowを開き、コメントタブに切替→入力欄上に二重線が出ないこと
- [ ] コメント一覧をスクロールしても境界線が濃くならないこと
- [ ] ページリロード後にInfoWindowを開き直してもコメント入力欄が1つだけ表示されること
- [ ] デスクトップ表示に影響がないこと

### 自動テスト
bin/rails test

## 関連issue
close #371