### PR TITLE
fix: モバイルでセレクトボックス表示を修正 (#383)

### DIFF
--- a/app/assets/stylesheets/ai/_condition_modal.scss
+++ b/app/assets/stylesheets/ai/_condition_modal.scss
@@ -110,10 +110,11 @@
 .ai-condition-modal__slot-select {
   width: 100%;
   padding: 8px 12px;
-  font-size: 14px;
+  font-size: 16px; // iOS zoom防止
   border: 1px solid #ddd;
   border-radius: 6px;
-  background: #fff;
+  background: #fff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E") no-repeat right 12px center;
+  appearance: none;
   cursor: pointer;
 
   &:focus {


### PR DESCRIPTION
## 概要
モバイル表示時に、AI条件モーダルの「提案件数」セレクトボックスがブラウザのネイティブスタイルとカスタムスタイルが競合して表示がおかしくなる問題を修正。

## 作業項目
- `appearance: none` でネイティブスタイルを無効化
- `font-size: 16px` でiOSズーム防止
- SVGでカスタム矢印アイコンを追加

## 変更ファイル
- `app/assets/stylesheets/ai/_condition_modal.scss`: セレクトボックスのスタイル修正

## 検証
### 手動テスト
- [x] モバイルでAI条件モーダルを開き、セレクトボックスが正常に表示される
- [x] セレクトボックスをタップして選択肢が正常に表示される
- [x] 選択後、値が正しく反映される

### 自動テスト
bin/rails test

## 関連issue
close #383