### PR TITLE
refactor: AiAreaServiceを責務分割 (#385)

### DIFF
--- a/app/services/ai_area/prompt_builder.rb
+++ b/app/services/ai_area/prompt_builder.rb
@@ -1,0 +1,92 @@
+# AI提案用プロンプト生成を担当
+#
+# 使い方:
+#   prompt = AiArea::PromptBuilder.plan_mode(slot_data, 10.0)
+#   prompt = AiArea::PromptBuilder.spot_mode(candidates, genre, 10.0)
+#
+module AiArea
+  class PromptBuilder
+    # 季節ガイド（ドライブの雰囲気づくり + 避けるべきもの）
+    SEASON_GUIDE = {
+      1 => "冬（冬景色や温泉が楽しめる。海や夏向けスポットは避ける）",
+      2 => "冬（冬景色や温泉が楽しめる。海や夏向けスポットは避ける）",
+      3 => "早春（春の訪れを感じるドライブ。まだ寒いので温泉も◎）",
+      4 => "春（桜や花を楽しむ最高の季節。自然散策や屋外スポットが◎）",
+      5 => "初夏（新緑が美しい季節。自然スポットや屋外が気持ちいい）",
+      6 => "梅雨（雨でも楽しめる施設やグルメがおすすめ。見晴らしスポットは天気次第）",
+      7 => "夏（水辺や高原で涼を求めるドライブ。炎天下の屋外散策は避ける）",
+      8 => "夏（避暑地や水辺が人気。暑さ対策できる場所を選びたい）",
+      9 => "初秋（まだ暑いが秋の気配。涼しい高原や秋の味覚が◎）",
+      10 => "秋（紅葉が始まり景色が美しい。温泉との組み合わせが◎）",
+      11 => "晩秋（紅葉見頃で絶景ドライブに最適。温泉との組み合わせが◎）",
+      12 => "冬（冬景色や温泉が楽しめる。海や夏向けスポットは避ける）"
+    }.freeze
+
+    class << self
+      # プランモード用プロンプトを生成
+      # @param slot_data [Array<Hash>] [{ genre_name:, candidates: [...] }, ...]
+      # @param radius_km [Float] 半径
+      # @return [String] プロンプト
+      def plan_mode(slot_data, radius_km)
+        month = Time.current.month
+        season = SEASON_GUIDE[month]
+        area_name = slot_data.first&.dig(:candidates)&.first&.dig(:city) || "選択エリア"
+
+        # スロットごとに候補を通し番号で列挙
+        index = 1
+        slots_info = slot_data.map do |slot|
+          spots_list = slot[:candidates].map do |s|
+            "#{index}.#{s[:name]}".tap { index += 1 }
+          end.join(" ")
+          "[#{slot[:genre_name]}] #{spots_list}"
+        end.join("\n")
+
+        <<~PROMPT
+          あなたはドライブプランAIです。
+
+          ■ #{month}月・#{season} / #{area_name}周辺（半径#{radius_km.round(1)}km）
+
+          ■ 候補スポット
+          #{slots_info}
+
+          ■ タスク
+          各ジャンルから季節に合った1件を必ず選出（同じジャンルから複数選ばない）。
+          ※自然・公園系は花や紅葉の見頃を考慮（例: コキアは秋、桜は春）
+
+          ■ 文章ルール（すべて敬語）
+          - intro: 地域の特徴や魅力（季節に言及しない）
+          - d: スポット固有の魅力（スポット名は含めない、季節は本当に関係する場合のみ）
+
+          ■ JSON
+          {"picks":[{"n":番号,"d":"1文"},...], "intro":"1文", "closing":"1文"}
+        PROMPT
+      end
+
+      # スポットモード用プロンプトを生成
+      # @param candidates [Array<Hash>] [spot_hash, ...]
+      # @param genre [Genre] 対象ジャンル
+      # @param radius_km [Float] 半径
+      # @return [String] プロンプト
+      def spot_mode(candidates, genre, radius_km)
+        area_name = candidates.first&.dig(:city) || "選択エリア"
+        spots_list = candidates.map { |s| s[:name] }.join("、")
+
+        <<~PROMPT
+          あなたはドライブスポット紹介AIです。
+
+          ■ #{area_name}周辺（半径#{radius_km.round(1)}km）
+          ■ ジャンル: #{genre.name}
+
+          ■ 人気スポット
+          #{spots_list}
+
+          ■ タスク
+          上記の人気スポットをシンプルに紹介。
+
+          ■ JSON
+          {"intro":"紹介文（1〜2文）","closing":"気になるスポットの追加を促す一言"}
+        PROMPT
+      end
+    end
+  end
+end

--- a/app/services/ai_area/spot_finder.rb
+++ b/app/services/ai_area/spot_finder.rb
@@ -1,0 +1,96 @@
+# 円内スポット検索を担当
+#
+# 使い方:
+#   finder = AiArea::SpotFinder.new(35.6, 139.7, 10.0)
+#   slot_data = finder.fetch_for_slots(slots)
+#   candidates = finder.fetch_for_genre(genre, 5)
+#
+module AiArea
+  class SpotFinder
+    # 緯度1度 ≈ 111km、経度1度 ≈ 91km（日本の緯度で概算）
+    LAT_KM = 111.0
+    LNG_KM = 91.0
+
+    def initialize(center_lat, center_lng, radius_km)
+      @center_lat = center_lat
+      @center_lng = center_lng
+      @radius_km = radius_km
+    end
+
+    # プランモード用: 各スロットに対して候補スポットを取得（人気順10件）
+    # @param slots [Array<Hash>] [{ genre_id: 5 }, ...]
+    # @return [Array<Hash>] [{ genre_name:, candidates: [spot_hash, ...] }, ...]
+    def fetch_for_slots(slots)
+      slots.filter_map do |slot|
+        genre_id = slot[:genre_id] || slot["genre_id"]
+        genre = Genre.find_by(id: genre_id)
+        next unless genre
+
+        candidates = fetch_candidates_by_genre(genre.id, 10)
+        next if candidates.empty?
+
+        { genre_name: genre.name, candidates: candidates }
+      end
+    end
+
+    # スポットモード用: 人気スポットを取得（人気順N件）
+    # @param genre [Genre] 対象ジャンル
+    # @param count [Integer] 取得件数
+    # @return [Array<Hash>] [spot_hash, ...]
+    def fetch_for_genre(genre, count)
+      fetch_candidates_by_genre(genre.id, count)
+    end
+
+    private
+
+    # 指定ジャンルの候補スポットを人気順で取得
+    def fetch_candidates_by_genre(genre_id, limit)
+      # まず円内+ジャンルでスポットIDを取得（DISTINCTを回避）
+      candidate_ids = spots_in_circle
+        .filter_by_genres([ genre_id ])
+        .pluck(:id)
+
+      return [] if candidate_ids.empty?
+
+      # お気に入り数上位N件を候補として取得
+      top_spot_ids = Spot
+        .where(id: candidate_ids)
+        .left_joins(:like_spots)
+        .group(:id)
+        .order("COUNT(like_spots.id) DESC")
+        .limit(limit)
+        .pluck(:id)
+
+      Spot.includes(:genres).where(id: top_spot_ids).map { |s| spot_to_hash(s) }
+    end
+
+    # 円内のスポットを取得するスコープ
+    def spots_in_circle
+      distance_sql = <<~SQL.squish
+        SQRT(
+          POW((lat - ?) * #{LAT_KM}, 2) +
+          POW((lng - ?) * #{LNG_KM}, 2)
+        )
+      SQL
+
+      Spot
+        .where("#{distance_sql} <= ?", @center_lat, @center_lng, @radius_km)
+        .includes(:genres)
+    end
+
+    # SpotレコードをHashに変換
+    def spot_to_hash(spot)
+      {
+        id: spot.id,
+        name: spot.name,
+        address: spot.address,
+        prefecture: spot.prefecture,
+        city: spot.city,
+        lat: spot.lat,
+        lng: spot.lng,
+        place_id: spot.place_id,
+        genres: spot.genres.map(&:name)
+      }
+    end
+  end
+end

--- a/app/services/ai_area_service.rb
+++ b/app/services/ai_area_service.rb
@@ -1,30 +1,11 @@
 # エリア選択によるAI提案機能
 #
 # 円内スポット検索と、ジャンル指定によるAI提案を行う
+# スポット検索は AiArea::SpotFinder、プロンプト生成は AiArea::PromptBuilder に委譲
 #
 class AiAreaService
   MODEL = "gpt-4o-mini".freeze
   MAX_TOKENS = 1024
-
-  # 緯度1度 ≈ 111km、経度1度 ≈ 91km（日本の緯度で概算）
-  LAT_KM = 111.0
-  LNG_KM = 91.0
-
-  # 季節ガイド（ドライブの雰囲気づくり + 避けるべきもの）
-  SEASON_GUIDE = {
-    1 => "冬（冬景色や温泉が楽しめる。海や夏向けスポットは避ける）",
-    2 => "冬（冬景色や温泉が楽しめる。海や夏向けスポットは避ける）",
-    3 => "早春（春の訪れを感じるドライブ。まだ寒いので温泉も◎）",
-    4 => "春（桜や花を楽しむ最高の季節。自然散策や屋外スポットが◎）",
-    5 => "初夏（新緑が美しい季節。自然スポットや屋外が気持ちいい）",
-    6 => "梅雨（雨でも楽しめる施設やグルメがおすすめ。見晴らしスポットは天気次第）",
-    7 => "夏（水辺や高原で涼を求めるドライブ。炎天下の屋外散策は避ける）",
-    8 => "夏（避暑地や水辺が人気。暑さ対策できる場所を選びたい）",
-    9 => "初秋（まだ暑いが秋の気配。涼しい高原や秋の味覚が◎）",
-    10 => "秋（紅葉が始まり景色が美しい。温泉との組み合わせが◎）",
-    11 => "晩秋（紅葉見頃で絶景ドライブに最適。温泉との組み合わせが◎）",
-    12 => "冬（冬景色や温泉が楽しめる。海や夏向けスポットは避ける）"
-  }.freeze
 
   class << self
     # AI提案を生成
@@ -40,16 +21,20 @@ class AiAreaService
     def generate(plan:, center_lat:, center_lng:, radius_km:, slots: [], mode: "plan", genre_id: nil, count: nil)
       return error_response("API設定エラー", mode: mode) unless api_key_configured?
 
+      finder = AiArea::SpotFinder.new(center_lat, center_lng, radius_km)
+
       # モードに応じて候補スポットを取得
       case mode
       when "plan"
-        slot_data = fetch_slot_candidates(center_lat, center_lng, radius_km, slots)
+        slot_data = finder.fetch_for_slots(slots)
         all_spots = slot_data.flat_map { |slot| slot[:candidates] }
         slot_sizes = slot_data.map { |slot| slot[:candidates].size }
+        prompt = AiArea::PromptBuilder.plan_mode(slot_data, radius_km)
       when "spots"
         genre = Genre.find_by(id: genre_id)
         return error_response("ジャンルが見つかりません", mode: mode) unless genre
-        all_spots = fetch_genre_candidates(center_lat, center_lng, radius_km, genre, count)
+        all_spots = finder.fetch_for_genre(genre, count)
+        prompt = AiArea::PromptBuilder.spot_mode(all_spots, genre, radius_km)
       else
         return error_response("不正なモードです", mode: nil)
       end
@@ -63,13 +48,7 @@ class AiAreaService
         }
       end
 
-      # プロンプト生成 → API呼び出し → 選出
-      prompt = case mode
-      when "plan"
-                 build_plan_mode_prompt(radius_km, slot_data)
-      when "spots"
-                 build_spot_mode_prompt(radius_km, genre, all_spots)
-      end
+      # API呼び出し → 選出
       ai_response = call_openai_api(prompt)
       selected_spots = case mode
       when "plan"
@@ -96,95 +75,6 @@ class AiAreaService
 
     def api_key_configured?
       ENV["OPENAI_API_KEY"].present?
-    end
-
-    # 円内のスポットを取得するスコープ
-    def spots_in_circle(center_lat, center_lng, radius_km)
-      # 簡易距離計算: SQRT(POW((lat - center) * 111, 2) + POW((lng - center) * 91, 2))
-      distance_sql = <<~SQL.squish
-        SQRT(
-          POW((lat - ?) * #{LAT_KM}, 2) +
-          POW((lng - ?) * #{LNG_KM}, 2)
-        )
-      SQL
-
-      Spot
-        .where("#{distance_sql} <= ?", center_lat, center_lng, radius_km)
-        .includes(:genres)
-    end
-
-    # 各スロットに対して候補スポットを取得（人気順10件）
-    # @return [Array<Hash>] [{ genre_name:, candidates: [spot_hash, ...] }, ...]
-    def fetch_slot_candidates(center_lat, center_lng, radius_km, slots)
-      slot_candidates = []
-
-      slots.each do |slot|
-        genre_id = slot[:genre_id] || slot["genre_id"]
-        genre = Genre.find_by(id: genre_id)
-        next unless genre
-
-        # まず円内+ジャンルでスポットIDを取得（DISTINCTを回避）
-        candidate_ids = spots_in_circle(center_lat, center_lng, radius_km)
-          .filter_by_genres([ genre_id ])
-          .pluck(:id)
-
-        next if candidate_ids.empty?
-
-        # お気に入り数上位10件を候補として取得
-        top_spot_ids = Spot
-          .where(id: candidate_ids)
-          .left_joins(:like_spots)
-          .group(:id)
-          .order("COUNT(like_spots.id) DESC")
-          .limit(10)
-          .pluck(:id)
-
-        candidates = Spot.includes(:genres).where(id: top_spot_ids).map { |s| spot_to_hash(s) }
-
-        slot_candidates << {
-          genre_name: genre.name,
-          candidates: candidates
-        }
-      end
-
-      slot_candidates
-    end
-
-    # スポットモード用: 人気スポットを取得（人気順N件）
-    # @return [Array<Hash>] [spot_hash, ...]
-    def fetch_genre_candidates(center_lat, center_lng, radius_km, genre, count)
-      # まず円内+ジャンルでスポットIDを取得（DISTINCTを回避）
-      candidate_ids = spots_in_circle(center_lat, center_lng, radius_km)
-        .filter_by_genres([ genre.id ])
-        .pluck(:id)
-
-      return [] if candidate_ids.empty?
-
-      # お気に入り数でソートして上位N件を取得（人気スポットとして確定）
-      top_spot_ids = Spot
-        .where(id: candidate_ids)
-        .left_joins(:like_spots)
-        .group(:id)
-        .order("COUNT(like_spots.id) DESC")
-        .limit(count)
-        .pluck(:id)
-
-      Spot.includes(:genres).where(id: top_spot_ids).map { |spot| spot_to_hash(spot) }
-    end
-
-    # SpotレコードをHashに変換
-    def spot_to_hash(spot)
-      {
-        id: spot.id,
-        name: spot.name,
-        address: spot.address,
-        prefecture: spot.prefecture,
-        city: spot.city,
-        lat: spot.lat,
-        lng: spot.lng,
-        place_id: spot.place_id,
-        genres: spot.genres.map(&:name)
-      }
     end
 
     # OpenAI API呼び出し（純粋なAPI通信のみ）
@@ -214,7 +104,6 @@ class AiAreaService
       picks = ai_response[:picks] || []
 
       selected = picks.filter_map do |pick|
-        # picks が [{n:, d:}, ...] 形式
         number = pick[:n]
         description = pick[:d]
         spot = all_spots[number - 1]
@@ -240,67 +129,10 @@ class AiAreaService
       result.compact
     end
 
-    def build_plan_mode_prompt(radius, slot_candidates)
-      month = Time.current.month
-      season = SEASON_GUIDE[month]
-      area_name = slot_candidates.first&.dig(:candidates)&.first&.dig(:city) || "選択エリア"
-
-      # スロットごとに候補を通し番号で列挙
-      index = 1
-      slots_info = slot_candidates.map do |slot|
-        spots_list = slot[:candidates].map do |s|
-          "#{index}.#{s[:name]}".tap { index += 1 }
-        end.join(" ")
-        "[#{slot[:genre_name]}] #{spots_list}"
-      end.join("\n")
-
-      <<~PROMPT
-        あなたはドライブプランAIです。
-
-        ■ #{month}月・#{season} / #{area_name}周辺（半径#{radius.round(1)}km）
-
-        ■ 候補スポット
-        #{slots_info}
-
-        ■ タスク
-        各ジャンルから季節に合った1件を必ず選出（同じジャンルから複数選ばない）。
-        ※自然・公園系は花や紅葉の見頃を考慮（例: コキアは秋、桜は春）
-
-        ■ 文章ルール（すべて敬語）
-        - intro: 地域の特徴や魅力（季節に言及しない）
-        - d: スポット固有の魅力（スポット名は含めない、季節は本当に関係する場合のみ）
-
-        ■ JSON
-        {"picks":[{"n":番号,"d":"1文"},...], "intro":"1文", "closing":"1文"}
-      PROMPT
-    end
-
-    def build_spot_mode_prompt(radius, genre, candidates)
-      area_name = candidates.first&.dig(:city) || "選択エリア"
-      spots_list = candidates.map { |s| s[:name] }.join("、")
-
-      <<~PROMPT
-        あなたはドライブスポット紹介AIです。
-
-        ■ #{area_name}周辺（半径#{radius.round(1)}km）
-        ■ ジャンル: #{genre.name}
-
-        ■ 人気スポット
-        #{spots_list}
-
-        ■ タスク
-        上記の人気スポットをシンプルに紹介。
-
-        ■ JSON
-        {"intro":"紹介文（1〜2文）","closing":"気になるスポットの追加を促す一言"}
-      PROMPT
-    end
-
     # 提案レスポンスを構築
     def build_suggest_response(ai_result, selected_spots, mode = "plan")
       intro = ai_result[:intro] || ""
 
-      # spotsを既存形式で構築
       spots_for_response = selected_spots.map do |spot|
         {
           spot_id: spot[:id],


### PR DESCRIPTION
## 概要
AiAreaService（337行）が複数の責務を持っていたため、3クラスに分割してテスト容易性と可読性を向上。

## 作業項目
- `AiArea::SpotFinder` を新規作成（円内スポット検索を担当）
- `AiArea::PromptBuilder` を新規作成（プロンプト生成を担当）
- `AiAreaService` をオーケストレーションに専念するよう整理

## 変更ファイル
- `app/services/ai_area_service.rb`: 337行 → 169行にスリム化
- `app/services/ai_area/spot_finder.rb`: 新規作成（96行）
- `app/services/ai_area/prompt_builder.rb`: 新規作成（92行）

## 検証
### 手動テスト
- [ ] プランモードでAI提案が正常に動作する
- [ ] スポットモードでAI提案が正常に動作する
- [ ] エラー時に適切なメッセージが表示される

### 自動テスト
bin/rails test

## 関連issue
close #385