### PR TITLE
fix: 出発時刻設定時のトグル展開 & AI提案ボタン不具合を修正

### DIFF
--- a/app/controllers/api/plans/start_points_controller.rb
+++ b/app/controllers/api/plans/start_points_controller.rb
@@ -22,7 +22,7 @@ module Api
           end
 
           # ✅ その他の更新は Turbo Stream で全体を再描画
-          @start_point_detail_open = true
+          @start_point_detail_open = false
 
           respond_to do |format|
             format.turbo_stream { render "plans/refresh_plan_tab" }

--- a/app/views/plans/_plan_form.html.erb
+++ b/app/views/plans/_plan_form.html.erb
@@ -1,7 +1,7 @@
 <% content_for :body_class, "no-footer" %>
 
 <div class="main-content plan-form"
-     data-controller="ui--navibar-resize suggestion-area-draw"
+     data-controller="ui--navibar-resize suggestion--area-draw"
      data-ui--navibar-resize-min-value="300"
      data-ui--navibar-resize-max-percent-value="80"
      data-ui--navibar-resize-default-value="350">


### PR DESCRIPTION
## 概要
2つのバグを修正しました。

## 作業項目
- 出発時刻設定時のトグル展開バグを修正
- AI提案ボタン（まるっとプラン提案・かこんでスポット検索）の不具合を修正

## 変更ファイル
- `app/controllers/api/plans/start_points_controller.rb`: `@start_point_detail_open = true` → `false`
- `app/views/plans/_plan_form.html.erb`: `suggestion-area-draw` → `suggestion--area-draw`

## 検証
### 手動テスト
- [x] 出発時刻を変更しても、トグルが閉じた状態のまま再描画される
- [x] 「まるっとプラン提案」ボタンをクリックするとエリア選択モードに入る
- [x] 「かこんでスポット検索」ボタンをクリックするとエリア選択モードに入る

### 自動テスト
```bash
bundle exec rspec
```

## 関連issue
close #406