### PR TITLE
refactor: move_cost関連カラム・コードを削除 (#409)

### DIFF
--- a/app/models/plan/directions_client.rb
+++ b/app/models/plan/directions_client.rb
@@ -15,7 +15,6 @@ require "json"
 # 出力:
 #   - move_time（分）
 #   - move_distance（km）
-#   - move_cost（Phase 2 では 0 固定）
 #   - polyline
 #
 class Plan::DirectionsClient
@@ -25,7 +24,6 @@ class Plan::DirectionsClient
   FALLBACK_RESULT = {
     move_time: 0,
     move_distance: 0.0,
-    move_cost: 0,
     polyline: nil
   }.freeze
 
@@ -34,7 +32,7 @@ class Plan::DirectionsClient
     # @param origin [Hash] { lat:, lng: }
     # @param destination [Hash] { lat:, lng: }
     # @param toll_used [Boolean] 有料道路を使用するか
-    # @return [Hash] { move_time:, move_distance:, move_cost:, polyline: }
+    # @return [Hash] { move_time:, move_distance:, polyline: }
     def fetch(origin:, destination:, toll_used: false)
       return FALLBACK_RESULT.dup unless valid_coordinates?(origin, destination)
 
@@ -103,7 +101,6 @@ class Plan::DirectionsClient
       {
         move_time: parse_duration(leg["duration"]),
         move_distance: parse_distance(leg["distance"]),
-        move_cost: 0, # Phase 2 では 0 固定
         polyline: route.dig("overview_polyline", "points")
       }
     end

--- a/app/models/plan/route.rb
+++ b/app/models/plan/route.rb
@@ -1,7 +1,7 @@
 # app/models/plan/route.rb
 # frozen_string_literal: true
 
-# 責務: 経路情報（move_time / move_distance / move_cost / polyline）を計算・保存
+# 責務: 経路情報（move_time / move_distance / polyline）を計算・保存
 #
 # 保存先ルール（不変）:
 #   - 「次の区間までの情報は出発側に保存する」
@@ -24,7 +24,6 @@ class Plan::Route
   FALLBACK_ROUTE_DATA = {
     move_time: 0,
     move_distance: 0.0,
-    move_cost: 0,
     polyline: nil
   }.freeze
 
@@ -165,7 +164,7 @@ class Plan::Route
 
   # 経路を計算（Google Directions API を呼び出し）
   # @param segment [Hash]
-  # @return [Hash] { move_time:, move_distance:, move_cost:, polyline: }
+  # @return [Hash] { move_time:, move_distance:, polyline: }
   def calculate_route(segment)
     @api_call_count += 1
 
@@ -183,7 +182,6 @@ class Plan::Route
     from_record.update!(
       move_time: route_data[:move_time],
       move_distance: route_data[:move_distance],
-      move_cost: route_data[:move_cost],
       polyline: route_data[:polyline]
     )
   end

--- a/app/models/plan_spot.rb
+++ b/app/models/plan_spot.rb
@@ -11,7 +11,7 @@ class PlanSpot < ApplicationRecord
 
   # Validations
   validates :spot_id, uniqueness: { scope: :plan_id, message: "は既にこのプランに追加されています" }
-  validates :move_time, :move_distance, :move_cost, numericality: { greater_than_or_equal_to: 0 }
+  validates :move_time, :move_distance, numericality: { greater_than_or_equal_to: 0 }
   validates :stay_duration, numericality: {
     greater_than_or_equal_to: 0,
     less_than_or_equal_to: MAX_STAY_DURATION,

--- a/db/migrate/20260201230444_remove_move_cost_columns.rb
+++ b/db/migrate/20260201230444_remove_move_cost_columns.rb
@@ -1,0 +1,7 @@
+class RemoveMoveCostColumns < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :start_points, :move_cost, :integer
+    remove_column :plan_spots, :move_cost, :integer, default: 0, null: false
+    remove_column :plans, :total_cost, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_01_110543) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_01_230444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -74,7 +74,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_01_110543) do
     t.datetime "created_at", null: false
     t.time "departure_time"
     t.text "memo"
-    t.integer "move_cost", default: 0, null: false
     t.float "move_distance", default: 0.0, null: false
     t.integer "move_time", default: 0, null: false
     t.bigint "plan_id", null: false
@@ -93,7 +92,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_01_110543) do
   create_table "plans", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "title"
-    t.integer "total_cost", default: 0, null: false
     t.float "total_distance", default: 0.0, null: false
     t.integer "total_time", default: 0, null: false
     t.datetime "updated_at", null: false
@@ -259,7 +257,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_01_110543) do
     t.time "departure_time"
     t.float "lat"
     t.float "lng"
-    t.integer "move_cost"
     t.float "move_distance"
     t.integer "move_time"
     t.bigint "plan_id", null: false

--- a/spec/factories/plan_spots.rb
+++ b/spec/factories/plan_spots.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     sequence(:position) { |n| n }
     move_time { 30 }
     move_distance { 10.5 }
-    move_cost { 0 }
     toll_used { false }
     stay_duration { 45 }
     arrival_time { nil }
@@ -15,7 +14,6 @@ FactoryBot.define do
 
     trait :with_toll do
       toll_used { true }
-      move_cost { 500 }
     end
 
     trait :with_memo do

--- a/spec/factories/start_points.rb
+++ b/spec/factories/start_points.rb
@@ -12,11 +12,9 @@ FactoryBot.define do
     toll_used { false }
     move_time { 30 }
     move_distance { 10.5 }
-    move_cost { 0 }
 
     trait :with_toll do
       toll_used { true }
-      move_cost { 500 }
     end
 
     trait :no_departure_time do

--- a/spec/models/plan/route_spec.rb
+++ b/spec/models/plan/route_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Plan::Route, type: :model do
       expect(described_class::FALLBACK_ROUTE_DATA).to eq({
         move_time: 0,
         move_distance: 0.0,
-        move_cost: 0,
         polyline: nil
       })
     end


### PR DESCRIPTION
## 概要
Google Maps APIでは有料道路料金（toll cost）を取得できないため、実装不可能なmove_cost関連のカラム・コードを削除しました。

## 作業項目
- `start_points.move_cost`、`plan_spots.move_cost`、`plans.total_cost` カラムを削除するマイグレーション作成
- モデル・サービスクラスからmove_cost参照を削除
- factory・specからmove_cost参照を削除

## 変更ファイル
- `db/migrate/20260201230444_remove_move_cost_columns.rb`: マイグレーション新規作成
- `app/models/plan_spot.rb`: バリデーションからmove_cost削除
- `app/models/plan/directions_client.rb`: FALLBACK_RESULT・戻り値からmove_cost削除
- `app/models/plan/route.rb`: FALLBACK_ROUTE_DATA・save_route_dataからmove_cost削除
- `spec/factories/plan_spots.rb`: move_cost属性削除
- `spec/factories/start_points.rb`: move_cost属性削除
- `spec/models/plan/route_spec.rb`: FALLBACK_ROUTE_DATA期待値からmove_cost削除

## 検証
### 手動テスト
- [ ] プラン作成・編集が正常に動作する
- [ ] 経路計算（有料道路ON/OFF）が正常に動作する
- [ ] 既存プランの閲覧が正常に動作する

### 自動テスト
```
bundle exec rspec spec/models/plan/route_spec.rb
# 20 examples, 0 failures
```

## 関連issue
close #409