### PR TITLE
fix: メール確認をスキップしてResendエラーを回避

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,9 +60,9 @@ class User < ApplicationRecord
     !sns_only_user?
   end
 
-  # SNS認証のみのユーザーはメール確認不要
+  # メール確認をスキップ（Resend独自ドメイン設定後に有効化予定）
   def confirmation_required?
-    !sns_only_user?
+    false
   end
 
   # OmniAuthコールバックからユーザーを検索


### PR DESCRIPTION
## 概要
新規登録時にResendのメール送信エラー（500 Internal Server Error）が発生する問題を修正。

Resendのテストドメイン（`onboarding@resend.dev`）では、アカウント所有者以外のメールアドレスへの送信ができないため、独自ドメイン設定完了まで確認メールをスキップする。

## 変更ファイル
- `app/models/user.rb`: `confirmation_required?` を常に `false` に変更

## 検証
### 手動テスト
- [x] メールアドレスで新規登録ができる
- [x] SNS認証で新規登録ができる
- [x] 登録後にプロフィール設定画面に遷移する

## 備考
- Resend独自ドメイン設定後に確認メール機能を有効化予定