### PR TITLE
fix: モバイルInfoWindow・ポリラインの表示不具合を修正 (#420)

### DIFF
--- a/app/assets/stylesheets/mobile/_infowindow.scss
+++ b/app/assets/stylesheets/mobile/_infowindow.scss
@@ -239,6 +239,7 @@
 
 /* 出発/帰宅地点用 */
 .mobile-infowindow__content .dp-infowindow--point {
+  width: 100%;
   padding: 16px;
 
   .dp-infowindow__header {

--- a/app/javascript/controllers/infowindow/mobile_controller.js
+++ b/app/javascript/controllers/infowindow/mobile_controller.js
@@ -66,15 +66,25 @@ export default class extends Controller {
     // ナビバーの状態を保存して最小化（先に実行して高さを取得）
     this.saveAndCollapseNavibar()
 
-    // 初期高さを設定（共通高さまたはデフォルト）
+    // 初期高さを設定
     const sheet = this.sheetTarget
     const isPoint = contentEl?.querySelector(".dp-infowindow--point")
-    const defaultPercent = isPoint ? 25 : 50
-    const heightPercent = this.savedHeightPercent ?? defaultPercent
-    const initialHeight = window.innerHeight * (heightPercent / 100)
+
     sheet.style.transition = "none"
-    sheet.style.height = `${initialHeight}px`
-    this.currentHeight = initialHeight
+
+    if (isPoint) {
+      // 出発/帰宅地点: コンテンツの高さに合わせる
+      sheet.style.height = "auto"
+      const contentHeight = sheet.scrollHeight
+      sheet.style.height = `${contentHeight}px`
+      this.currentHeight = contentHeight
+    } else {
+      // スポット: 共通高さまたはデフォルト50%
+      const heightPercent = this.savedHeightPercent ?? 50
+      const initialHeight = window.innerHeight * (heightPercent / 100)
+      sheet.style.height = `${initialHeight}px`
+      this.currentHeight = initialHeight
+    }
 
 
     // 写真ギャラリー連携（infowindow-ui → photo-gallery）

--- a/app/javascript/controllers/suggestion/area_draw_controller.js
+++ b/app/javascript/controllers/suggestion/area_draw_controller.js
@@ -125,7 +125,8 @@ export default class extends Controller {
       path: [],
       strokeColor: "#667eea",
       strokeWeight: 3,
-      strokeOpacity: 0.8
+      strokeOpacity: 0.8,
+      zIndex: 1,
     })
 
     this.addPoint(e)

--- a/app/javascript/map/constants.js
+++ b/app/javascript/map/constants.js
@@ -24,6 +24,7 @@ export const ROUTE_POLYLINE_STYLE = {
   strokeColor: COLORS.MY_PLAN,
   strokeOpacity: 0.85,
   strokeWeight: 4,
+  zIndex: 1,
 }
 
 /**
@@ -33,6 +34,7 @@ export const COMMUNITY_ROUTE_STYLE = {
   strokeColor: COLORS.COMMUNITY,
   strokeOpacity: 0.7,
   strokeWeight: 4,
+  zIndex: 1,
 }
 
 /**


### PR DESCRIPTION
## 概要
モバイル時の出発/帰宅地点InfoWindowの表示崩れと、ポリラインがマーカーの上に重なる問題を修正。

## 作業項目
- 出発/帰宅地点InfoWindowの高さをコンテンツに合わせる
- 出発/帰宅地点InfoWindowの横幅を100%に修正
- ポリラインにzIndex:1を追加してマーカーの下に表示

## 変更ファイル
- `app/assets/stylesheets/mobile/_infowindow.scss`: width: 100%を追加
- `app/javascript/controllers/infowindow/mobile_controller.js`: 出発/帰宅地点の高さをコンテンツに合わせる
- `app/javascript/map/constants.js`: ポリラインスタイルにzIndex: 1を追加
- `app/javascript/controllers/suggestion/area_draw_controller.js`: エリア描画ポリラインにzIndex: 1を追加

## 検証
### 手動テスト
- [x] モバイルで出発地点InfoWindowが正しいサイズで表示される
- [x] モバイルで帰宅地点InfoWindowが正しいサイズで表示される
- [x] ポリラインがマーカーの下に表示される（ちらつきなし）

## 関連issue
close #420