### PR TITLE
fix: 位置情報確認ダイアログが2回表示される問題を修正 (#431)

### DIFF
--- a/app/javascript/map/current_location.js
+++ b/app/javascript/map/current_location.js
@@ -6,13 +6,30 @@
 import { getMapInstance, setCurrentLocationMarker } from "map/state";
 import { COLORS } from "map/constants";
 
-export const addCurrentLocationMarker = ({ panTo = false } = {}) => {
+export const addCurrentLocationMarker = async ({ panTo = false } = {}) => {
   const map = getMapInstance();
   if (!map) return;
 
   if (!navigator.geolocation) {
     console.warn("Geolocation はこのブラウザでサポートされていません");
     return;
+  }
+
+  // Permissions API で許可状態を確認（未許可なら確認ダイアログを出さずにスキップ）
+  if (navigator.permissions) {
+    try {
+      const permission = await navigator.permissions.query({ name: "geolocation" });
+      if (permission.state === "denied") {
+        console.warn("位置情報の使用が拒否されています");
+        return;
+      }
+      if (permission.state === "prompt") {
+        // 未確認の場合はスキップ（プラン作成時に確認済みのはず）
+        return;
+      }
+    } catch (e) {
+      // Permissions API 非対応ブラウザは従来通り
+    }
   }
 
   navigator.geolocation.getCurrentPosition(


### PR DESCRIPTION
## 概要
プラン作成時に位置情報の確認ダイアログが2回表示される問題を修正しました。Permissions APIを使用して、許可状態を確認してから位置情報を取得するようにしました。

## 作業項目
- Permissions APIで位置情報の許可状態を確認
- 未許可(prompt)の場合は現在地マーカー表示をスキップ
- 許可済み(granted)の場合のみ位置情報を取得

## 変更ファイル
- `app/javascript/map/current_location.js`: Permissions APIによる許可状態確認を追加

## 検証
### 手動テスト
- [x] 位置情報未許可状態でプラン作成 → 確認ダイアログが1回のみ表示されること
- [x] 位置情報許可済み状態でプラン作成 → 確認ダイアログなしで現在地マーカーが表示されること
- [x] 位置情報拒否済み状態でプラン作成 → 現在地マーカーが表示されないこと

### 自動テスト
- N/A（ブラウザAPI依存のため）

## 関連issue
close #431