### PR TITLE
メール確認送信修正

### DIFF
--- a/app/assets/stylesheets/pages/_guide.scss
+++ b/app/assets/stylesheets/pages/_guide.scss
@@ -16,18 +16,10 @@
   cursor: grab;
   user-select: none;
   overflow: hidden;
+  touch-action: pan-y; /* 横スワイプをJSに委譲 */
 
   &:active {
     cursor: grabbing;
-  }
-
-  /* スワイプ有効化 */
-  .carousel {
-    touch-action: pan-y pinch-zoom;
-  }
-
-  .carousel-inner {
-    touch-action: pan-x;
   }
 
   /* リンク・ボタンは通常カーソル */
@@ -151,6 +143,11 @@
 .guide-page .carousel-control-prev,
 .guide-page .carousel-control-next {
   display: none;
+}
+
+/* 遷移速度を速くする */
+.guide-page .carousel-item {
+  transition-duration: 0.3s;
 }
 
 /* スライド */

--- a/app/assets/stylesheets/plans/_plan_detail.scss
+++ b/app/assets/stylesheets/plans/_plan_detail.scss
@@ -244,6 +244,11 @@ body.no-footer .plan-detail {
   /* ✅ 詳細画面用スポットアイコン（コミュニティ青） */
   .spot-block--show .spot-order-icon {
     background: linear-gradient(135deg, #4A90D9, #2C5FA0);
+
+    /* CSSカウンターを無効化（HTML直接表示を使用） */
+    &::before {
+      content: none;
+    }
   }
 
   /* ✅ スポット間の矢印 */

--- a/app/javascript/controllers/suggestion/plan_adopt_controller.js
+++ b/app/javascript/controllers/suggestion/plan_adopt_controller.js
@@ -137,6 +137,9 @@ export default class extends Controller {
     const map = getMapInstance()
     if (!map) return
 
+    // 既存の提案マーカーをクリア（重複防止）
+    clearSuggestionMarkers()
+
     this._resolvedSpots.forEach((spot, index) => {
       const position = { lat: spot.lat, lng: spot.lng }
 

--- a/app/javascript/controllers/suggestion/spots_batch_controller.js
+++ b/app/javascript/controllers/suggestion/spots_batch_controller.js
@@ -3,6 +3,7 @@ import {
   getMapInstance,
   addSuggestionMarker,
   addSuggestionOverlay,
+  clearSuggestionMarkers,
 } from "map/state"
 import { showInfoWindowWithFrame, closeInfoWindow } from "map/infowindow"
 import { createSuggestionPinSvg } from "map/constants"
@@ -68,6 +69,9 @@ export default class extends Controller {
   #processAllSpots() {
     const map = getMapInstance()
     if (!map) return
+
+    // 既存の提案マーカーをクリア（重複防止）
+    clearSuggestionMarkers()
 
     // 子要素からスポットカードを取得
     const cards = this.element.querySelectorAll("[data-controller*='suggestion--suggested-spot']")

--- a/app/views/plans/_plan_detail.html.erb
+++ b/app/views/plans/_plan_detail.html.erb
@@ -105,21 +105,12 @@
        class="mobile-infowindow"
        data-controller="infowindow--mobile"
        hidden>
-    <div class="mobile-infowindow__backdrop" data-action="click->infowindow--mobile#close"></div>
     <div class="mobile-infowindow__sheet" data-infowindow--mobile-target="sheet">
       <div class="mobile-infowindow__handle" data-infowindow--mobile-target="handle">
         <div class="mobile-infowindow__handle-bar"></div>
       </div>
-      <button type="button"
-              class="mobile-infowindow__close-btn"
-              data-action="click->infowindow--mobile#close">
-        <i class="bi bi-x-lg"></i>
-      </button>
       <div class="mobile-infowindow__content" id="mobile-infowindow-content">
-        <%# InfoWindow コンテンツがここに挿入される %>
-      </div>
-      <div class="mobile-infowindow__footer" id="mobile-infowindow-footer" hidden>
-        <%# コメントフッターがJSで移動される %>
+        <%# InfoWindow コンテンツがここに挿入される（閉じるボタン含む） %>
       </div>
     </div>
   </div>

--- a/app/views/settings/email.html.erb
+++ b/app/views/settings/email.html.erb
@@ -58,7 +58,7 @@
         <div class="auth-divider">または</div>
 
         <div class="auth-links auth-links--compact">
-          <%= link_to "パスワードを忘れた場合", new_user_password_path %>
+          <%= link_to "パスワードをお忘れですか？", new_user_password_path %>
         </div>
       </div>
     <% end %>

--- a/app/views/spots/_spot_detail.html.erb
+++ b/app/views/spots/_spot_detail.html.erb
@@ -82,21 +82,12 @@
        class="mobile-infowindow"
        data-controller="infowindow--mobile"
        hidden>
-    <div class="mobile-infowindow__backdrop" data-action="click->infowindow--mobile#close"></div>
     <div class="mobile-infowindow__sheet" data-infowindow--mobile-target="sheet">
       <div class="mobile-infowindow__handle" data-infowindow--mobile-target="handle">
         <div class="mobile-infowindow__handle-bar"></div>
       </div>
-      <button type="button"
-              class="mobile-infowindow__close-btn"
-              data-action="click->infowindow--mobile#close">
-        <i class="bi bi-x-lg"></i>
-      </button>
       <div class="mobile-infowindow__content" id="mobile-infowindow-content">
-        <%# InfoWindow コンテンツがここに挿入される %>
-      </div>
-      <div class="mobile-infowindow__footer" id="mobile-infowindow-footer" hidden>
-        <%# コメントフッターがJSで移動される %>
+        <%# InfoWindow コンテンツがここに挿入される（閉じるボタン含む） %>
       </div>
     </div>
   </div>

--- a/app/views/static_pages/guide.html.erb
+++ b/app/views/static_pages/guide.html.erb
@@ -12,7 +12,7 @@
   </div>
 
   <!-- カルーセル -->
-  <div id="guideCarousel" class="carousel slide h-100" data-bs-touch="true" data-bs-interval="false" data-bs-ride="false">
+  <div id="guideCarousel" class="carousel slide h-100" data-bs-touch="false" data-bs-interval="false" data-bs-ride="false">
     <div class="carousel-inner h-100">
       <!-- スライド1: イントロ -->
       <div class="carousel-item active h-100" data-page="1">

--- a/app/views/suggestions/_message.html.erb
+++ b/app/views/suggestions/_message.html.erb
@@ -62,9 +62,11 @@
            data-suggestion-target="spotSuggestions"
            data-controller="suggestion--spots-batch"
            data-suggestion--spots-batch-auto-show-value="<%= auto_show_value %>">
-        <% spot_list.each_with_index do |spot, index| %>
-          <%= render "suggestions/spot_suggestion", spot: spot, plan: plan, number: index + 1, existing_place_ids: existing_place_ids %>
-        <% end %>
+        <div class="suggestion__spots-inner">
+          <% spot_list.each_with_index do |spot, index| %>
+            <%= render "suggestions/spot_suggestion", spot: spot, plan: plan, number: index + 1, existing_place_ids: existing_place_ids %>
+          <% end %>
+        </div>
       </div>
     <% end %>
 


### PR DESCRIPTION
## 概要
メールアドレス変更時の確認メール送信不具合と、複数のUI不具合をまとめて修正。

## 作業項目

### #438 メール変更時の確認メール送信修正
- Devise 5.0 + Rails 8 で `email=` セッターが正しくオーバーライドされない問題を修正
- カスタム reconfirmation フローを User モデルに実装

### #439 UI不具合修正
- InfoWindow 閉じるボタン重複修正（詳細画面）
- ガイドページのスワイプ/ドラッグ修正（Pointer Events + Bootstrap ESM インポート）
- 地図パン（panToVisualCenter）のボトムシート考慮改善
- 出発/帰宅地点変更後の地図移動改善
- 提案マーカーの重複防止
- プラン詳細の CSS カウンター無効化
- 提案スポットリストの wrapper 追加

## 変更ファイル
- `app/models/user.rb`: カスタム email= セッター・reconfirmation メソッド追加
- `app/views/settings/email.html.erb`: フラッシュメッセージ修正
- `app/views/plans/_plan_detail.html.erb`: モバイル InfoWindow 閉じるボタン重複削除
- `app/views/spots/_spot_detail.html.erb`: 同上
- `app/assets/stylesheets/pages/_guide.scss`: touch-action 修正・遷移速度改善
- `app/javascript/controllers/ui/swipe_carousel_controller.js`: Pointer Events + Bootstrap ESM インポート
- `app/views/static_pages/guide.html.erb`: data-bs-touch="false" に変更
- `app/javascript/map/visual_center.js`: ボトムシート高さ計算改善・panTo/panBy 競合防止
- `app/javascript/controllers/infowindow/point_editor_controller.js`: 地点変更後の地図移動改善
- `app/javascript/controllers/suggestion/plan_adopt_controller.js`: マーカー重複防止
- `app/javascript/controllers/suggestion/spots_batch_controller.js`: マーカー重複防止
- `app/assets/stylesheets/plans/_plan_detail.scss`: CSS カウンター無効化
- `app/views/suggestions/_message.html.erb`: spots-inner wrapper 追加

## 検証
### 手動テスト
- [x] メールアドレス変更時に確認メールが送信される
- [x] 変更後のフラッシュメッセージが正しい
- [x] 詳細画面の InfoWindow に閉じるボタンが1つだけ表示される
- [x] ガイドページでスワイプ（モバイル）/ドラッグ（デスクトップ）が動作する
- [x] 地図パンがボトムシートを考慮して正しく動作する
- [x] 提案マーカーが重複しない

### 自動テスト
- スタイル・JS 変更が中心のためテスト対象外

## 関連issue
close #438
close #439