### PR TITLE
feat: スポット追加時の滞在時間デフォルトを1時間に設定 (#442)

### DIFF
--- a/app/assets/stylesheets/plans/navibar/_time_rail.scss
+++ b/app/assets/stylesheets/plans/navibar/_time_rail.scss
@@ -185,7 +185,7 @@ body.goal-point-visible .time-rail-block--goal {
 .spot-stay-duration__label {
   font-size: 0.7rem;
   font-weight: 500;
-  color: rgb(35, 35, 35);
+  color: rgba(33, 33, 33, 0.6);
   line-height: 1.2;
   letter-spacing: 0.01em;
 }
@@ -195,7 +195,7 @@ body.goal-point-visible .time-rail-block--goal {
   align-items: baseline;
   justify-content: center;
 
-  color: #2d2d2d;
+  color: #555;
   font-size: 14px;
   font-weight: 500;
   letter-spacing: 0.02em;
@@ -205,7 +205,7 @@ body.goal-point-visible .time-rail-block--goal {
 .spot-stay-duration__unit {
   font-size: 10px;
   font-weight: 400;
-  color: #2d2d2d;
+  color: #555;
   margin: 0 1px;
   vertical-align: baseline;
 }

--- a/app/models/plan_spot.rb
+++ b/app/models/plan_spot.rb
@@ -6,8 +6,11 @@ class PlanSpot < ApplicationRecord
   # 順序管理（plan スコープで position を自動採番）
   acts_as_list scope: :plan
 
-  # 滞在時間の上限（20時間 = 1200分）※ホテル滞在を考慮
+  # 滞在時間のデフォルト（60分）と上限（20時間 = 1200分）※ホテル滞在を考慮
+  DEFAULT_STAY_DURATION = 60
   MAX_STAY_DURATION = 1200
+
+  attribute :stay_duration, :integer, default: DEFAULT_STAY_DURATION
 
   # Validations
   validates :spot_id, uniqueness: { scope: :plan_id, message: "は既にこのプランに追加されています" }


### PR DESCRIPTION
## 概要
スポットをプランに追加する際、滞在時間のデフォルト値を60分（1時間）に設定。毎回手動入力する手間を省き、「追加してあとで調整」のフローをスムーズにする。併せてタイムレールの滞在時間ラベル色を到着・出発と統一。

## 作業項目
- PlanSpotモデルに `attribute :stay_duration, :integer, default: 60` を追加
- 滞在時間ラベル・値の色を到着・出発と統一

## 変更ファイル
- `app/models/plan_spot.rb`: デフォルト滞在時間60分を設定
- `app/assets/stylesheets/plans/navibar/_time_rail.scss`: 滞在時間ラベル・値の色調整

## 検証
### 手動テスト
- [ ] 新規スポット追加時に滞在時間が「1時間0分」で表示される
- [ ] 滞在時間ピッカーで変更後、正しく保存される
- [ ] 既存スポット（滞在時間未設定）の表示に影響がない

### 自動テスト
- RSpec: 10 examples, 0 failures（PlanSpot model spec）

## 関連issue
close #442