### PR TITLE
feat: SNS共有モーダルにリンクコピー機能を追加 (#443)

### DIFF
--- a/app/assets/stylesheets/shared/_share_buttons.scss
+++ b/app/assets/stylesheets/shared/_share_buttons.scss
@@ -162,6 +162,56 @@
   background: #06c755;
 }
 
+.share-modal__link-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 16px 16px;
+  padding: 0;
+  background: transparent;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.share-modal__link-input {
+  flex: 1;
+  min-width: 0;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  font-size: 13px;
+  color: #555;
+  outline: none;
+  text-overflow: ellipsis;
+}
+
+.share-modal__link-copy {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: transparent;
+  color: #007aff;
+  font-size: 18px;
+  cursor: pointer;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: #005ec4;
+  }
+
+  &:active {
+    transform: scale(0.9);
+  }
+
+  &--done {
+    color: #34c759;
+  }
+}
+
 .share-modal__cancel {
   width: 100%;
   padding: 14px 16px;

--- a/app/javascript/controllers/ui/share_modal_controller.js
+++ b/app/javascript/controllers/ui/share_modal_controller.js
@@ -80,6 +80,12 @@ export default class extends Controller {
               <span>LINE</span>
             </button>
           </div>
+          <div class="share-modal__link-row">
+            <input type="text" class="share-modal__link-input" value="${this.urlValue}" readonly>
+            <button type="button" class="share-modal__link-copy">
+              <i class="bi bi-copy" aria-hidden="true"></i>
+            </button>
+          </div>
           <button type="button" class="share-modal__cancel">キャンセル</button>
         </div>
       </div>
@@ -90,6 +96,7 @@ export default class extends Controller {
     modal.querySelector(".share-modal__cancel").addEventListener("click", () => this.close())
     modal.querySelector(".share-modal__btn--x").addEventListener("click", () => this.shareX())
     modal.querySelector(".share-modal__btn--line").addEventListener("click", () => this.shareLine())
+    modal.querySelector(".share-modal__link-copy").addEventListener("click", (e) => this.copyLink(e))
 
     return modal
   }
@@ -103,6 +110,27 @@ export default class extends Controller {
       "noopener,noreferrer"
     )
     this.close()
+  }
+
+  async copyLink(e) {
+    const btn = e.currentTarget
+    const icon = btn.querySelector("i")
+    const input = this.modal.querySelector(".share-modal__link-input")
+
+    try {
+      await navigator.clipboard.writeText(this.urlValue)
+    } catch {
+      // HTTP環境用フォールバック: inputを選択してexecCommand
+      input.select()
+      document.execCommand("copy")
+    }
+
+    icon.className = "bi bi-check-lg"
+    btn.classList.add("share-modal__link-copy--done")
+    setTimeout(() => {
+      icon.className = "bi bi-copy"
+      btn.classList.remove("share-modal__link-copy--done")
+    }, 1500)
   }
 
   shareLine() {


### PR DESCRIPTION
## 概要
SNS共有モーダルにURL表示+コピーボタンを追加。X/LINEに加え、URLをクリップボードにコピーして他の手段（メール、メッセンジャー等）で共有可能にする。

## 作業項目
- 共有モーダルにURL表示欄+コピーボタンを追加
- Clipboard APIでワンクリックコピー（HTTP環境用にexecCommandフォールバック付き）
- コピー完了時にアイコンがチェックマークに変化するフィードバック

## 変更ファイル
- `app/javascript/controllers/ui/share_modal_controller.js`: リンク行HTML追加、`copyLink()`メソッド追加
- `app/assets/stylesheets/shared/_share_buttons.scss`: リンク行・コピーボタンのスタイル追加

## 検証
### 手動テスト
- [x] コピーボタンクリックでURLがクリップボードにコピーされる
- [x] コピー後にアイコンがチェックマークに変化し、1.5秒後に戻る
- [x] HTTP環境（localhost）でもフォールバックでコピーが動作する
- [x] X/LINE共有が引き続き正常に動作する

### 自動テスト
- JSのみの変更のため、手動テストで検証

## 関連issue
close #443