### PR TITLE
fix: AI提案結果表示時にエリア描画円が消える不具合を修正 (#456)

### DIFF
--- a/app/javascript/controllers/suggestion_tab/plan_adopt_controller.js
+++ b/app/javascript/controllers/suggestion_tab/plan_adopt_controller.js
@@ -137,9 +137,6 @@ export default class extends Controller {
     const map = getMapInstance()
     if (!map) return
 
-    // 既存の提案マーカーをクリア（重複防止）
-    clearSuggestionMarkers()
-
     this._resolvedSpots.forEach((spot, index) => {
       const position = { lat: spot.lat, lng: spot.lng }
 

--- a/app/javascript/controllers/suggestion_tab/spots_batch_controller.js
+++ b/app/javascript/controllers/suggestion_tab/spots_batch_controller.js
@@ -3,7 +3,6 @@ import {
   getMapInstance,
   addSuggestionMarker,
   addSuggestionOverlay,
-  clearSuggestionMarkers,
 } from "map/state"
 import { showInfoWindowWithFrame, closeInfoWindow } from "map/infowindow"
 import { createSuggestionPinSvg } from "map/constants"
@@ -69,9 +68,6 @@ export default class extends Controller {
   #processAllSpots() {
     const map = getMapInstance()
     if (!map) return
-
-    // 既存の提案マーカーをクリア（重複防止）
-    clearSuggestionMarkers()
 
     // 子要素からスポットカードを取得
     const cards = this.element.querySelectorAll("[data-controller*='suggestion-tab--suggested-spot']")


### PR DESCRIPTION
## 概要
AI提案でエリアを描画し提案を実行すると、結果（スポット/プラン）が表示されたタイミングでエリア描画円が消えてしまう不具合を修正。

`plan_adopt_controller` と `spots_batch_controller` の auto-show フローで `clearSuggestionMarkers()` を呼んでいたが、この関数はマーカーだけでなくエリア円も消去していた。Turbo Stream結果が届く時点で旧マーカーは既に消去済み（描画開始時・条件変更時・エリア再選択時に各コントローラで消去される）のため、この呼び出しは冗長かつエリア円を誤って消す原因だった。

## 作業項目
- `plan_adopt_controller.js` の `#showMarkersOnMap()` 内の `clearSuggestionMarkers()` を削除
- `spots_batch_controller.js` の `#processAllSpots()` 内の `clearSuggestionMarkers()` を削除
- `spots_batch_controller.js` の未使用 import を削除

## 変更ファイル
- `app/javascript/controllers/suggestion_tab/plan_adopt_controller.js`: auto-show時の冗長な `clearSuggestionMarkers()` 呼び出しを削除
- `app/javascript/controllers/suggestion_tab/spots_batch_controller.js`: 同上 + 未使用importを削除

## 検証
### 手動テスト
- [x] AI提案でエリアを描画 → 結果表示後もエリア円が残る
- [x] 「エリアを選び直す」で円が正しく消える
- [x] 「会話をクリア」で円+ピンが正しく消える
- [x] 「このプランを採用」後にピンが正しく消える

### 自動テスト
- JSのみの変更のため、手動テストで検証

## 関連issue
close #456