### PR TITLE
docs: READMEを全面改訂 (#408)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ DrivePeekは、地図検索・AI提案・みんなのプランの3つの方法�
       <img src="https://github.com/user-attachments/assets/f0629f22-8a9d-452b-9bfc-d89a7ca27a95" alt="モバイル対応" height="400">
     </td>
     <td width="50%" align="center">
-      <img src="https://i.gyazo.com/710e58461ac63124d54ecb7f7b6f3847.png" alt="ナビ連携" height="400">
+      <img src="https://github.com/user-attachments/assets/4cde3215-106f-45f4-a95a-a2156e60154b" alt="ナビ連携" height="400">
     </td>
   </tr>
   <tr>
@@ -144,7 +144,7 @@ app/javascript/controllers/
 
 ## ER図
 
-<img alt="ER図" src="https://i.gyazo.com/301ff37253a0d2e6e3dcaa906b9c8971.png" />
+<img alt="ER図" src="https://github.com/user-attachments/assets/bca35b99-5b83-4301-95f1-ab2561062052" />
 
 
 ## テスト


### PR DESCRIPTION
## 概要
READMEを全面リニューアル。機能紹介・技術構成・技術的チャレンジ・開発背景を整理し、全画像をGitHub hostingに統一。

## 作業項目
- READMEの構成・内容を全面的にリニューアル
- GIF画像をGyazoからGitHubにホスティング移行
- ヒーロー画像をアプリ実画面に変更
- ER図・ナビ連携画像もGitHub hostingに統一
- 技術選定の理由を正確な内容に修正
- 「プラン」を主軸にした表現に統一
- 開発背景の3課題を「スポット探し・時間計算・プラン共有」に修正

## 変更ファイル
- `README.md`: ポートフォリオ向けに全面更新

## 検証
### 手動テスト
- [x] GitHubでREADMEが正しく表示される
- [x] 全てのGIF画像が表示される
- [x] ヒーロー画像が表示される
- [x] ER図が表示される
- [x] リンク（サービスURL、Figma）が機能する

### 自動テスト
- N/A（ドキュメント変更のみ）

## 関連issue
close #408