### PR TITLE
refactor: InfowindowsController のリファクタリング

### DIFF
--- a/app/controllers/infowindows_controller.rb
+++ b/app/controllers/infowindows_controller.rb
@@ -7,34 +7,10 @@ class InfowindowsController < ApplicationController
   before_action :authenticate_user!, only: :create
   # GET /infowindow
   # Turbo Frame用：spotId または place_id でInfoWindow HTMLを返す
-  # Google API は1回のみ呼び出し（photos 取得）
   def show
-    @edit_mode = params[:edit_mode]
-
-    # ログイン前はAPI呼び出しなしでゲスト用UIを返す（コスト削減）
-    unless user_signed_in?
-      return render partial: "map/infowindow_guest", locals: guest_locals
-    end
-
-    # 出発・帰宅地点の場合はシンプルなパーシャルを返す（ログイン後のみ）
-    if @edit_mode.present?
-      partial = params[:mobile] == "true" ? "map/infowindow_home_mobile" : "map/infowindow_home"
-      return render partial: partial, locals: home_locals
-    end
-
-    @spot = find_or_create_spot
-    @photo_urls = fetch_photo_urls
-    @show_button = params[:show_button].to_s != "false"
-    @button_label = params[:button_label]
-    @map_mode = params[:map_mode]
-    @plan_spot_id = find_plan_spot_id
-
-    # モバイル用パーシャルを返す
-    if params[:mobile] == "true"
-      render partial: "map/infowindow_spot_mobile", locals: infowindow_locals_mobile
-    else
-      render partial: "map/infowindow_spot", locals: infowindow_locals
-    end
+    return render_guest unless user_signed_in?
+    return render_home if edit_mode?
+    render_spot
   end
 
   # POST /infowindow
@@ -47,12 +23,49 @@ class InfowindowsController < ApplicationController
     @button_label = params[:button_label]
     @map_mode = params[:map_mode]
     @plan_spot_id = find_plan_spot_id
-    @edit_buttons = parse_edit_buttons
 
     render partial: "map/infowindow_spot", locals: infowindow_locals
   end
 
   private
+
+  def render_guest
+    render partial: "map/infowindow_guest", locals: guest_locals
+  end
+
+  def render_home
+    partial = mobile? ? "map/infowindow_home_mobile" : "map/infowindow_home"
+    render partial: partial, locals: home_locals
+  end
+
+  def render_spot
+    @spot = find_or_create_spot
+    @photo_urls = fetch_photo_urls
+    @show_button = params[:show_button].to_s != "false"
+    @button_label = params[:button_label]
+    @map_mode = params[:map_mode]
+    @plan_spot_id = find_plan_spot_id
+
+    partial = mobile? ? "map/infowindow_spot_mobile" : "map/infowindow_spot"
+    locals = mobile? ? infowindow_locals_mobile : infowindow_locals
+    render partial: partial, locals: locals
+  end
+
+  def edit_mode?
+    params[:edit_mode].present?
+  end
+
+  def mobile?
+    params[:mobile] == "true"
+  end
+
+  def zoom_index
+    @zoom_index ||= (params[:zoom_index] || MapHelper::INFOWINDOW_DEFAULT_ZOOM_INDEX).to_i
+  end
+
+  def zoom_scale
+    @zoom_scale ||= MapHelper::INFOWINDOW_ZOOM_SCALES[zoom_index] || "md"
+  end
 
   def find_or_create_spot
     # spot_idが指定されていれば既存spotを返す
@@ -99,76 +112,38 @@ class InfowindowsController < ApplicationController
   end
 
   def find_plan_spot_id
-    return nil unless user_signed_in?
+    return unless user_signed_in? && params[:plan_id].present?
 
-    plan_id = params[:plan_id]
-    return nil unless plan_id.present?
+    plan = current_user.plans.find_by(id: params[:plan_id])
+    return unless plan
 
-    plan = current_user.plans.find_by(id: plan_id)
-    return nil unless plan
-
-    # spotId で検索
     if params[:spot_id].present?
-      plan_spot = plan.plan_spots.find_by(spot_id: params[:spot_id])
-      return plan_spot&.id if plan_spot
-    end
-
-    # placeId で検索
-    if params[:place_id].present?
-      plan_spot = plan.plan_spots.joins(:spot).find_by(spots: { place_id: params[:place_id] })
-      return plan_spot&.id
-    end
-
-    nil
-  end
-
-  def parse_edit_buttons
-    buttons = params[:edit_buttons]
-    return [] if buttons.blank?
-
-    buttons.map do |btn|
-      {
-        id: btn[:id],
-        label: btn[:label],
-        variant: btn[:variant],
-        action: btn[:action]
-      }
+      plan.plan_spots.find_by(spot_id: params[:spot_id])&.id
+    elsif params[:place_id].present?
+      plan.plan_spots.joins(:spot).find_by(spots: { place_id: params[:place_id] })&.id
     end
   end
 
   def home_locals
-    zoom_index = (params[:zoom_index] || MapHelper::INFOWINDOW_DEFAULT_ZOOM_INDEX).to_i
-    zoom_scale = MapHelper::INFOWINDOW_ZOOM_SCALES[zoom_index] || "md"
-
     # DBから住所を取得（自分のプラン → 公開プランの順で検索）
     plan = current_user.plans.find_by(id: params[:plan_id]) ||
            Plan.publicly_visible.find_by(id: params[:plan_id])
-    point = @edit_mode == "start_point" ? plan&.start_point : plan&.goal_point
-    address = point&.address
+    point = params[:edit_mode] == "start_point" ? plan&.start_point : plan&.goal_point
 
     {
       name: params[:name],
-      address: address,
-      edit_mode: @edit_mode,
+      address: point&.address,
+      edit_mode: params[:edit_mode],
       zoom_scale: zoom_scale,
       plan_id: params[:plan_id]
     }
   end
 
   def guest_locals
-    zoom_index = (params[:zoom_index] || MapHelper::INFOWINDOW_DEFAULT_ZOOM_INDEX).to_i
-    zoom_scale = MapHelper::INFOWINDOW_ZOOM_SCALES[zoom_index] || "md"
-
-    {
-      zoom_scale: zoom_scale,
-      zoom_index: zoom_index
-    }
+    { zoom_scale: zoom_scale, zoom_index: zoom_index }
   end
 
   def infowindow_locals
-    zoom_index = (params[:zoom_index] || MapHelper::INFOWINDOW_DEFAULT_ZOOM_INDEX).to_i
-    zoom_scale = MapHelper::INFOWINDOW_ZOOM_SCALES[zoom_index] || "md"
-
     {
       spot: @spot,
       photo_urls: @photo_urls,
@@ -177,7 +152,7 @@ class InfowindowsController < ApplicationController
       map_mode: @map_mode,
       plan_id: params[:plan_id],
       plan_spot_id: @plan_spot_id,
-      edit_mode: @edit_mode,
+      edit_mode: params[:edit_mode],
       zoom_scale: zoom_scale,
       zoom_index: zoom_index,
       default_tab: params[:default_tab]


### PR DESCRIPTION
## 概要
InfowindowsController を整理し、可読性を向上させる。205行 → 173行（-16%）。

## 作業項目
- `show` メソッドを4行に簡略化（`render_guest`/`render_home`/`render_spot` に分割）
- `edit_mode?`, `mobile?`, `zoom_index`, `zoom_scale` ヘルパーを追加
- `parse_edit_buttons`（死にコード）を削除
- `find_plan_spot_id` を簡略化（22行→10行）
- `zoom_index`/`zoom_scale` の重複を削除

## 変更ファイル
- `app/controllers/infowindows_controller.rb`: リファクタリング（-32行）

## 検証
### 手動テスト
- [x] ログイン前にInfoWindowが表示される（ゲストUI）
- [x] 出発/帰宅地点のInfoWindowが表示される
- [x] スポットのInfoWindowが表示される（デスクトップ/モバイル）

### 自動テスト
- RSpec: 12 examples, 0 failures
- RuboCop: no offenses detected

## 関連issue
close #493