### PR TITLE
refactor: ジャンルマスタの整理（温泉カテゴリ統合）

### DIFF
--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,7 +1,7 @@
 # app/models/genre.rb
 class Genre < ApplicationRecord
   # カテゴリの表示順序
-  CATEGORY_ORDER = %w[食べる 見る 買う お風呂 動物 自然 遊ぶ 泊まる].freeze
+  CATEGORY_ORDER = %w[食べる 見る 買う 温まる 動物 自然 遊ぶ 泊まる].freeze
 
   # 親子関係
   belongs_to :parent, class_name: "Genre", optional: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -81,11 +81,9 @@ GENRES = [
   { name: "記念館・資料館", slug: "memorial_hall", category: "見る", visible: true, parent_slug: "museum_category", emoji: "🏛️" },
 
   # ==========================================
-  # お風呂
+  # 温まる
   # ==========================================
-  { name: "温泉", slug: "onsen", category: "お風呂", visible: true, emoji: "♨️" },
-  { name: "サウナ", slug: "sauna", category: "お風呂", visible: true, emoji: "♨️" },
-  { name: "スパ銭", slug: "super_sento", category: "お風呂", visible: true, emoji: "♨️" },
+  { name: "温泉", slug: "bath", category: "温まる", visible: true, emoji: "♨️" },
 
   # ==========================================
   # 動物

--- a/spec/factories/genres.rb
+++ b/spec/factories/genres.rb
@@ -12,9 +12,9 @@ FactoryBot.define do
       slug { "gourmet" }
     end
 
-    trait :onsen do
-      name { "温泉・スパ" }
-      slug { "onsen" }
+    trait :bath do
+      name { "温泉" }
+      slug { "bath" }
     end
 
     trait :sightseeing do

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Genre, type: :model do
     end
 
     it "CATEGORY_ORDER順で並ぶ" do
-      create(:genre, name: "温泉", category: "お風呂", visible: true, parent: nil)
+      create(:genre, name: "温泉", category: "温まる", visible: true, parent: nil)
 
       result = Genre.grouped_by_category
 

--- a/spec/models/suggestion/generator_spec.rb
+++ b/spec/models/suggestion/generator_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Suggestion::Generator do
     end
 
     context "該当スポットがない場合" do
-      let!(:genre) { create(:genre, name: "温泉", slug: "onsen") }
+      let!(:genre) { create(:genre, name: "温泉", slug: "bath") }
 
       before do
         allow(ENV).to receive(:[]).and_call_original
@@ -201,7 +201,7 @@ RSpec.describe Suggestion::Generator do
 
     context "フォールバック動作" do
       let!(:genre1) { create(:genre, name: "グルメ", slug: "gourmet") }
-      let!(:genre2) { create(:genre, name: "温泉", slug: "onsen") }
+      let!(:genre2) { create(:genre, name: "温泉", slug: "bath") }
       let!(:spot1) { create(:spot, lat: 35.6770, lng: 139.6510, name: "グルメスポット") }
       let!(:spot2) { create(:spot, lat: 35.6780, lng: 139.6520, name: "温泉スポット") }
 

--- a/spec/requests/suggestions_spec.rb
+++ b/spec/requests/suggestions_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Suggestions", type: :request do
   describe "POST /suggestions/suggest" do
     context "プランモード" do
       let!(:genre_gourmet) { create(:genre, name: "グルメ", slug: "gourmet") }
-      let!(:genre_onsen) { create(:genre, name: "温泉", slug: "onsen") }
+      let!(:genre_bath) { create(:genre, name: "温泉", slug: "bath") }
       let!(:spot) do
         create(:spot, lat: 35.6770, lng: 139.6510, name: "テストスポット").tap do |s|
           s.genres << genre_gourmet
@@ -55,12 +55,12 @@ RSpec.describe "Suggestions", type: :request do
         end
 
         it "複数スロットでAI提案を取得する" do
-          spot_onsen = create(:spot, lat: 35.6780, lng: 139.6520)
-          spot_onsen.genres << genre_onsen
+          spot_bath = create(:spot, lat: 35.6780, lng: 139.6520)
+          spot_bath.genres << genre_bath
 
           post suggest_suggestions_path, params: area_params.merge(
             mode: "plan",
-            slots: [ { genre_id: genre_gourmet.id }, { genre_id: genre_onsen.id } ]
+            slots: [ { genre_id: genre_gourmet.id }, { genre_id: genre_bath.id } ]
           ), headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
           expect(response).to have_http_status(:ok)

--- a/spec/services/suggestion/spot_finder_spec.rb
+++ b/spec/services/suggestion/spot_finder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suggestion::SpotFinder, type: :service do
     let(:finder) { described_class.new(center_lat, center_lng, radius_km) }
 
     let!(:genre_gourmet) { create(:genre, name: "グルメ", slug: "gourmet") }
-    let!(:genre_onsen) { create(:genre, name: "温泉", slug: "onsen") }
+    let!(:genre_bath) { create(:genre, name: "温泉", slug: "bath") }
 
     context "円内にスポットがある場合" do
       let!(:spot_in_circle) do
@@ -36,10 +36,10 @@ RSpec.describe Suggestion::SpotFinder, type: :service do
       end
 
       it "複数スロットに対応する" do
-        spot_onsen = create(:spot, lat: 35.6780, lng: 139.6520)
-        spot_onsen.genres << genre_onsen
+        spot_bath = create(:spot, lat: 35.6780, lng: 139.6520)
+        spot_bath.genres << genre_bath
 
-        slots = [ { genre_id: genre_gourmet.id }, { genre_id: genre_onsen.id } ]
+        slots = [ { genre_id: genre_gourmet.id }, { genre_id: genre_bath.id } ]
         result = finder.fetch_for_slots(slots)
 
         expect(result.length).to eq(2)


### PR DESCRIPTION
## 概要
ジャンルマスタを整理し、温泉関連のカテゴリを統合。

## 作業項目
- サウナ・スパ銭ジャンルを削除し温泉に統合
- 温泉ジャンルのslugを `onsen` → `bath` に変更
- カテゴリ「お風呂」を「温まる」に変更
- CATEGORY_ORDERを更新
- 関連テストを修正

## 変更ファイル
- `db/seeds.rb`: ジャンル定義の変更
- `app/models/genre.rb`: CATEGORY_ORDERの更新
- `spec/factories/genres.rb`: factoryのtrait変更
- `spec/models/genre_spec.rb`: テスト修正
- `spec/models/suggestion/generator_spec.rb`: テスト修正
- `spec/requests/suggestions_spec.rb`: テスト修正
- `spec/services/suggestion/spot_finder_spec.rb`: テスト修正

## 検証
### 手動テスト
- [ ] ジャンル選択モーダルで「温まる」カテゴリが表示される
- [ ] 温泉ジャンルが正しく選択・フィルタできる
- [ ] 検索フィルタで温泉カテゴリが機能する

### 自動テスト
- RSpec: 45 examples, 0 failures

## 関連issue
close #520