### PR TITLE
fix: UIの細かな調整（ヘッダーバー・保存モーダル）

### DIFF
--- a/app/assets/stylesheets/map/_map_header_bar.scss
+++ b/app/assets/stylesheets/map/_map_header_bar.scss
@@ -204,7 +204,7 @@
   .map-header-bar {
     // navibar分を左にオフセット
     left: calc(var(--navibar-width, 350px) - var(--navibar-slide, 0px) + 6px);
-    right: 6px;
+    right: 54px; // ハンバーガー分のスペース確保（40px + 余白）
     gap: 8px;
 
     &__search-input {

--- a/app/javascript/controllers/ui/save_modal_controller.js
+++ b/app/javascript/controllers/ui/save_modal_controller.js
@@ -60,7 +60,7 @@ export default class extends Controller {
     modal.querySelector(".btn-cancel").addEventListener("click", () => this.close())
     modal.querySelector(".btn-primary").addEventListener("click", () => this.save())
     modal.querySelector(".plan-save-modal__input").addEventListener("keydown", (e) => {
-      if (e.key === "Enter") this.save()
+      if (e.key === "Enter" && !e.isComposing) this.save()
     })
 
     return modal


### PR DESCRIPTION
## 概要
地図画面のUIに関する細かな修正を行いました。ヘッダーバーのレイアウト崩れ防止と、保存モーダルでの日本語入力時の誤動作を修正しています。

## 作業項目
- ヘッダーバーの右マージンをハンバーガーメニュー分確保
- 保存モーダルでIME変換中のEnterキー誤発火を防止

## 変更ファイル
- `app/assets/stylesheets/map/_map_header_bar.scss`: 右マージンを6px→54pxに変更（ハンバーガーメニュー40px + 余白）
- `app/javascript/controllers/ui/save_modal_controller.js`: `e.isComposing`チェックを追加してIME変換確定時の誤発火を防止

## 検証
### 手動テスト
- [ ] PC幅でヘッダーバーがハンバーガーメニューと重ならないこと
- [ ] 保存モーダルで日本語入力時、変換確定のEnterで保存されないこと
- [ ] 保存モーダルで入力完了後のEnterで正常に保存されること
- [ ] モバイル表示でレイアウトが崩れないこと

### 自動テスト
- 該当なし（UI調整のみ）