### PR TITLE
fix: みんなの旅/お気に入りページで自分のプランに編集・削除ボタンを表示

### DIFF
--- a/app/views/community/_results.html.erb
+++ b/app/views/community/_results.html.erb
@@ -57,9 +57,12 @@
       <% favorite_plans_map = FavoritePlan.index_by_plan_id(user: current_user, plan_ids: @community_plans.map(&:id)) %>
       <div class="list-page__cards">
         <% @community_plans.each do |plan| %>
+          <% is_owner = current_user&.id == plan.user_id %>
           <%= render "plans/plan_card",
                      plan: plan,
                      favorite_plan: favorite_plans_map[plan.id],
+                     can_edit: is_owner,
+                     can_delete: is_owner,
                      preview_mode: turbo_frame %>
         <% end %>
       </div>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -53,7 +53,8 @@
         <% favorite_plans_map = FavoritePlan.index_by_plan_id(user: current_user, plan_ids: @plans.map(&:id)) %>
         <div class="list-page__cards">
           <% @plans.each do |plan| %>
-            <%= render "plans/plan_card", plan: plan, favorite_plan: favorite_plans_map[plan.id] %>
+            <% is_owner = current_user&.id == plan.user_id %>
+            <%= render "plans/plan_card", plan: plan, favorite_plan: favorite_plans_map[plan.id], can_edit: is_owner, can_delete: is_owner %>
           <% end %>
         </div>
 


### PR DESCRIPTION
## 概要
みんなの旅ページ、お気に入りページで自分が作成したプランに編集ボタン・削除ボタンが表示されるように修正

## 作業項目
- plan_cardパーシャルにcan_edit, can_deleteパラメータを渡すように修正

## 変更ファイル
- `app/views/community/_results.html.erb`: is_owner変数を追加し、can_edit, can_deleteを設定
- `app/views/favorites/index.html.erb`: 同様の修正

## 検証
### 手動テスト
- [x] みんなの旅ページで自分のプランに編集ボタンが表示される
- [x] みんなの旅ページで自分のプランに削除ボタンが表示される
- [x] お気に入りページで自分のプランに編集・削除ボタンが表示される

### 自動テスト
- RSpec: 639 examples, 0 failures
- Coverage: 98.37%

## 関連issue
close #547