### PR TITLE
feat: スポット詳細画面に「ここからプランを作る」機能を追加

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -36,10 +36,19 @@ class PlansController < ApplicationController
 
     @plan = Plan.create_with_location(user: current_user, lat: lat, lng: lng)
 
-    # コピー元があればスポットをコピー
+    # プラン詳細画面「このプランで作る」ボタン
     if params[:copy_from].present?
       source = Plan.publicly_visible.find_by(id: params[:copy_from])
       @plan.copy_spots_from(source) if source
+    end
+
+    # スポット詳細画面「ここからプランを作る」ボタン
+    if params[:add_spot].present?
+      spot = Spot.find_by(id: params[:add_spot])
+      if spot
+        @plan.plan_spots.create!(spot: spot)
+        @plan.recalculate_for!(nil, action: :create)
+      end
     end
 
     redirect_to edit_plan_path(@plan)

--- a/app/views/map/_infowindow_skeleton.html.erb
+++ b/app/views/map/_infowindow_skeleton.html.erb
@@ -53,9 +53,7 @@
           <span class="dp-infowindow__skeleton-text" style="width: 80%;"></span>
         </div>
         <div data-slot="button">
-          <button type="button" class="dp-infowindow__btn" disabled>
-            プランに追加
-          </button>
+          <%# ボタンはJSで動的に設定（編集画面: プランに追加、スポット詳細: ここからプランを作る） %>
         </div>
       </div>
     </div>

--- a/app/views/map/_infowindow_spot.html.erb
+++ b/app/views/map/_infowindow_spot.html.erb
@@ -130,9 +130,23 @@
       <div class="dp-infowindow__name"><%= safe_name %></div>
       <div class="dp-infowindow__address"><%= safe_address %></div>
 
-      <% if map_mode == "show" && user_signed_in? %>
-        <%= link_to "プランを作る", authenticated_root_path, class: "dp-infowindow__btn dp-infowindow__btn--create", data: { turbo_frame: "_top" } %>
+      <% if map_mode == "show" %>
+        <%# プラン詳細画面: ボタンなし（地図下部の「このプランで作る」ボタンを使用） %>
+      <% elsif map_mode == "spot_show" %>
+        <%# スポット詳細画面: ここからプランを作る %>
+        <% if user_signed_in? %>
+          <button type="button"
+                  class="dp-infowindow__btn dp-infowindow__btn--create"
+                  data-controller="ui--create-plan-trigger"
+                  data-ui--create-plan-trigger-url-value="<%= plans_path(add_spot: spot.id) %>"
+                  data-action="click->ui--create-plan-trigger#create">
+            ここからプランを作る
+          </button>
+        <% else %>
+          <%= link_to "ここからプランを作る", new_user_session_path, class: "dp-infowindow__btn dp-infowindow__btn--create", data: { turbo_frame: "_top" } %>
+        <% end %>
       <% elsif show_button && plan_id.present? %>
+        <%# 編集画面: プランに追加/削除 %>
         <% plan_spot = plan_spot_id.present? ? PlanSpot.find_by(id: plan_spot_id) : nil %>
         <%= render "map/infowindow_spot_button", spot: spot, plan_id: plan_id, plan_spot: plan_spot %>
       <% end %>

--- a/app/views/map/_infowindow_spot_mobile.html.erb
+++ b/app/views/map/_infowindow_spot_mobile.html.erb
@@ -111,9 +111,23 @@
     <% end %>
 
     <%# アクションボタン %>
-    <% if map_mode == "show" && user_signed_in? %>
-      <%= link_to "プランを作る", authenticated_root_path, class: "dp-infowindow__btn dp-infowindow__btn--create", data: { turbo_frame: "_top" } %>
+    <% if map_mode == "show" %>
+      <%# プラン詳細画面: ボタンなし（地図下部の「このプランで作る」ボタンを使用） %>
+    <% elsif map_mode == "spot_show" %>
+      <%# スポット詳細画面: ここからプランを作る %>
+      <% if user_signed_in? %>
+        <button type="button"
+                class="dp-infowindow__btn dp-infowindow__btn--create"
+                data-controller="ui--create-plan-trigger"
+                data-ui--create-plan-trigger-url-value="<%= plans_path(add_spot: spot.id) %>"
+                data-action="click->ui--create-plan-trigger#create">
+          ここからプランを作る
+        </button>
+      <% else %>
+        <%= link_to "ここからプランを作る", new_user_session_path, class: "dp-infowindow__btn dp-infowindow__btn--create", data: { turbo_frame: "_top" } %>
+      <% end %>
     <% elsif show_button && plan_id.present? %>
+      <%# 編集画面: プランに追加/削除 %>
       <% plan_spot = plan_spot_id.present? ? PlanSpot.find_by(id: plan_spot_id) : nil %>
       <%= render "map/infowindow_spot_button", spot: spot, plan_id: plan_id, plan_spot: plan_spot %>
     <% end %>

--- a/app/views/plans/_plan_detail.html.erb
+++ b/app/views/plans/_plan_detail.html.erb
@@ -17,20 +17,30 @@
   <%= render "map/infowindow_skeleton" %>
 
   <!-- 地図 -->
-  <div id="map" class="map" data-map-mode="show" data-plan-id="<%= @plan.id %>" data-ui--navibar-resize-target="map"></div>
+  <div id="map" class="map"
+       data-map-mode="show"
+       data-plan-id="<%= @plan.id %>"
+       data-user-signed-in="<%= user_signed_in? %>"
+       data-ui--navibar-resize-target="map"></div>
 
   <%# 地図上部のヘッダーバー（検索 + ジャンル/盛り上がり + ハンバーガー） %>
   <%= render "shared/map_header_bar" %>
 
   <!-- デスクトップ用：地図下部中央のアクションボタン -->
   <div class="map-bottom-actions">
-    <button type="button"
-            class="map-bottom-actions__btn map-bottom-actions__btn--copy map-bottom-actions__btn--single"
-            data-controller="ui--create-plan-trigger"
-            data-ui--create-plan-trigger-copy-from-value="<%= @plan.id %>"
-            data-action="click->ui--create-plan-trigger#create">
-      このプランで作る
-    </button>
+    <% if current_user %>
+      <button type="button"
+              class="map-bottom-actions__btn map-bottom-actions__btn--copy map-bottom-actions__btn--single"
+              data-controller="ui--create-plan-trigger"
+              data-ui--create-plan-trigger-url-value="<%= plans_path(copy_from: @plan.id) %>"
+              data-action="click->ui--create-plan-trigger#create">
+        このプランで作る
+      </button>
+    <% else %>
+      <%= link_to new_user_session_path, class: "map-bottom-actions__btn map-bottom-actions__btn--copy map-bottom-actions__btn--single" do %>
+        このプランで作る
+      <% end %>
+    <% end %>
   </div>
 
   <!-- 検索結果クリアボタン -->

--- a/app/views/spots/_spot_detail.html.erb
+++ b/app/views/spots/_spot_detail.html.erb
@@ -1,4 +1,5 @@
 <% content_for :body_class, "no-footer" %>
+<% content_for :hide_header, true %>
 
 <script>
   window.spotData = {
@@ -22,7 +23,32 @@
   <%= render "map/infowindow_skeleton" %>
 
   <!-- 地図 -->
-  <div id="map" class="map" data-map-mode="spot_show" data-spot-id="<%= @spot.id %>" data-ui--navibar-resize-target="map"></div>
+  <div id="map" class="map"
+       data-map-mode="spot_show"
+       data-spot-id="<%= @spot.id %>"
+       data-user-signed-in="<%= user_signed_in? %>"
+       data-ui--navibar-resize-target="map"></div>
+
+  <%# 地図上部のヘッダーバー（検索 + ジャンル/盛り上がり + ハンバーガー） %>
+  <%= render "shared/map_header_bar" %>
+
+  <!-- デスクトップ用：地図下部中央のアクションボタン -->
+  <div class="map-bottom-actions">
+    <% if current_user %>
+      <button type="button"
+              class="map-bottom-actions__btn map-bottom-actions__btn--copy map-bottom-actions__btn--single"
+              data-controller="ui--create-plan-trigger"
+              data-ui--create-plan-trigger-url-value="<%= plans_path(add_spot: @spot.id) %>"
+              data-ui--create-plan-trigger-listen-spot-change-value="true"
+              data-action="click->ui--create-plan-trigger#create">
+        ここからプランを作る
+      </button>
+    <% else %>
+      <%= link_to new_user_session_path, class: "map-bottom-actions__btn map-bottom-actions__btn--copy map-bottom-actions__btn--single" do %>
+        ここからプランを作る
+      <% end %>
+    <% end %>
+  </div>
 
   <!-- リサイズハンドル -->
   <div class="navibar-resize-handle"


### PR DESCRIPTION
## 概要
スポット詳細画面から、そのスポットを含んだプランを作成できる導線を追加

## 作業項目
- スポット詳細画面に「ここからプランを作る」ボタンを追加
- InfoWindow内にスポット詳細用ボタンを追加
- マーカークリック時に地図下部ボタンのスポットIDを動的更新
- 未ログイン時はログインページへリダイレクト
- プラン詳細画面のInfoWindowからボタンを削除（地図下部ボタンに統一）
- add_spot時に経路計算を実行

## 変更ファイル
- `app/controllers/plans_controller.rb`: add_spot時にrecalculate_for!を呼び出し
- `app/javascript/controllers/ui/create_plan_trigger_controller.js`: 動的スポット更新機能追加
- `app/javascript/map/infowindow.js`: spot_showモード対応、イベント発火
- `app/views/map/_infowindow_skeleton.html.erb`: デフォルトボタン削除
- `app/views/map/_infowindow_spot.html.erb`: spot_showモードのボタン追加
- `app/views/map/_infowindow_spot_mobile.html.erb`: 同上（モバイル）
- `app/views/plans/_plan_detail.html.erb`: user-signed-in属性追加
- `app/views/spots/_spot_detail.html.erb`: ボタン追加、動的更新対応

## 検証
### 手動テスト
- [x] スポット詳細画面で「ここからプランを作る」ボタンが表示される
- [x] ボタンクリックでプラン作成画面に遷移し、スポットが追加されている
- [x] 近くの似たスポットをクリック後、ボタンがそのスポットに更新される
- [x] 未ログイン時はログインページへリダイレクトされる

### 自動テスト
- RSpec: 639 examples, 0 failures
- Coverage: 98.37%

## 関連issue
close #548