### PR TITLE
feat: drivepeek.app 独自ドメイン対応

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,9 +3,11 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # ホスト制限対策
   config.hosts << "drivepeek.onrender.com"
+  config.hosts << "drivepeek.app"
+  config.hosts << "www.drivepeek.app"
 
   # デフォルトURL設定（OGP等の絶対URL生成用）
-  config.action_controller.default_url_options = { host: "drivepeek.onrender.com", protocol: "https" }
+  config.action_controller.default_url_options = { host: "drivepeek.app", protocol: "https" }
 
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -64,7 +66,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "drivepeek.onrender.com", protocol: "https" }
+  config.action_mailer.default_url_options = { host: "drivepeek.app", protocol: "https" }
 
   # Resend でメール送信
   config.action_mailer.delivery_method = :resend


### PR DESCRIPTION
## 概要
独自ドメイン `drivepeek.app` からのアクセスを許可する設定を追加。
Rails 7+ の Host Authorization により、許可されていないホストからのリクエストが 403 エラーになっていた問題を修正。

## 作業項目
- `config.hosts` に `drivepeek.app` と `www.drivepeek.app` を追加
- `default_url_options` のホストを `drivepeek.app` に変更（OGP・メール等の絶対URL生成用）

## 変更ファイル
- `config/environments/production.rb`: ホスト許可設定とデフォルトURL設定を更新

## 検証
### 手動テスト
- [x] `https://drivepeek.app` にアクセスしてサイトが表示される
- [x] `https://www.drivepeek.app` にアクセスしてリダイレクトされる
- [x] `https://drivepeek.onrender.com` も引き続き動作する
- [x] ログイン・プラン作成・保存が問題なく行える

## 関連issue
ref #259

※ ドメイン取得・DNS設定・SSL証明書発行は完了済み。このPRはRails側の対応のみ。
※ README更新等の残作業は別途対応。