### PR TITLE
refactor: エリア描画ボタンをCSS表示切替に統一 (#559)

### DIFF
--- a/app/assets/stylesheets/shared/_search_filters.scss
+++ b/app/assets/stylesheets/shared/_search_filters.scss
@@ -467,6 +467,20 @@
   }
 }
 
+/* 円エリア検索: デフォルト非表示、plan-form内で表示 */
+.search-filters__circle-area {
+  display: none;
+}
+
+.plan-form .search-filters__circle-area {
+  display: block;
+}
+
+/* エリア選択ボタン: デフォルト表示、plan-form内で非表示 */
+.plan-form .search-filters__area-btn {
+  display: none;
+}
+
 /* 選択リスト（iOS/Mac風） */
 $ios-blue: #007AFF;
 $ios-separator: rgba(60, 60, 67, 0.12);

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -33,8 +33,8 @@
         </div>
       <% end %>
 
-      <%# 円エリア検索（地図画面のみ表示） %>
-      <% if local_assigns[:map_mode] %>
+      <%# 円エリア検索（plan-form内でのみCSS表示） %>
+      <div class="search-filters__circle-area">
         <%# 初期状態：エリアを囲んで選択 %>
         <button type="button"
                 class="search-filters__select-btn"
@@ -54,16 +54,14 @@
           <span>エリア選択中（半径 <%= circle&.dig(:radius_km)&.round(1) || 0 %> km）</span>
           <i class="bi bi-x"></i>
         </button>
-      <% end %>
+      </div>
 
       <div class="search-filters">
-        <%# エリア選択ボタン（地図画面では円エリア検索を使うため非表示） %>
-        <% unless local_assigns[:map_mode] %>
-          <button type="button" class="search-filters__select-btn" data-action="click->community-tab--search-filters#showArea">
-            <span data-community-tab--search-filters-target="areaLabel"><%= format_selected_cities(selected_cities, cities_by_prefecture) %></span>
-            <i class="bi bi-plus"></i>
-          </button>
-        <% end %>
+        <%# エリア選択ボタン（plan-form外でのみCSS表示） %>
+        <button type="button" class="search-filters__select-btn search-filters__area-btn" data-action="click->community-tab--search-filters#showArea">
+          <span data-community-tab--search-filters-target="areaLabel"><%= format_selected_cities(selected_cities, cities_by_prefecture) %></span>
+          <i class="bi bi-plus"></i>
+        </button>
 
         <%# ジャンル選択ボタン %>
         <button type="button" class="search-filters__select-btn" data-action="click->community-tab--search-filters#showGenre">


### PR DESCRIPTION
## 概要
プラン作成画面のみんなの旅タブで「エリアをかこんで選択」ボタンが表示されない問題を修正。
`map_mode`パラメータを廃止し、#556で実装したCSS表示切替パターンに統一。

## 作業項目
- `map_mode`パラメータの条件分岐を削除
- 円エリア検索ボタンとエリア選択ボタンを両方HTML出力
- CSSで`.plan-form`親要素の有無により表示切替

## 変更ファイル
- `app/views/shared/_search_form.html.erb`: 条件分岐削除、両ボタン出力
- `app/assets/stylesheets/shared/_search_filters.scss`: CSS表示切替ルール追加

## 検証
### 手動テスト
- [x] プラン作成画面のみんなの旅タブで「エリアをかこんで選択」が表示される
- [x] スタンドアロンのみんなの旅ページでエリア選択ボタンが表示される
- [x] 円エリア検索が正しく動作する

### 自動テスト
- RSpec: 652 examples, 0 failures

## 関連issue
close #559