### PR TITLE
fix: みんなの旅タブ初回読み込み時のスクロールをスキップ (#561)

### DIFF
--- a/app/javascript/controllers/community_tab/scroll_controller.js
+++ b/app/javascript/controllers/community_tab/scroll_controller.js
@@ -9,6 +9,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
+    this.isInitialLoad = true
     this.handleFrameLoad = this.scrollToResults.bind(this)
     this.element.addEventListener("turbo:frame-load", this.handleFrameLoad)
   }
@@ -18,6 +19,12 @@ export default class extends Controller {
   }
 
   scrollToResults() {
+    // 初回読み込みはスキップ（タブ切り替え時）
+    if (this.isInitialLoad) {
+      this.isInitialLoad = false
+      return
+    }
+
     const scrollContainer = this.element.closest(".navibar__content-scroll")
     if (!scrollContainer) return
 


### PR DESCRIPTION
## 概要
みんなの旅タブに切り替えた際、初回読み込みでも結果バーへのスクロール処理が発生してしまう問題を修正。

## 作業項目
- `isInitialLoad` フラグを追加し、初回読み込み時はスクロールをスキップ

## 変更ファイル
- `app/javascript/controllers/community_tab/scroll_controller.js`: 初回読み込みスキップ処理を追加

## 検証
### 手動テスト
- [x] タブ切り替え時（初回）: スクロールしない
- [x] ページネーション時: 結果バーまでスクロールする
- [x] 検索実行時: 結果バーまでスクロールする

### 自動テスト
- RSpec: 652 examples, 0 failures
- Coverage: 98.26%

## 関連issue
close #561