### PR TITLE
地図画面のプランカードで削除・編集ボタンを非表示にする

### DIFF
--- a/app/assets/stylesheets/plans/cards/_plan_card.scss
+++ b/app/assets/stylesheets/plans/cards/_plan_card.scss
@@ -360,6 +360,15 @@ $card-text-muted: #999;
   }
 }
 
+/* ナビバー内: 削除・編集ボタンを非表示 */
+.navibar .plan-card__actions {
+  display: none;
+}
+
+.navibar .plan-card__detail-link--edit {
+  display: none;
+}
+
 /* 長いコンテンツ時かつ狭いコンテナ時のみマージン調整 */
 @container list-page (max-width: 280px) {
   .plan-card__footer--long {

--- a/app/views/shared/_plan_card.html.erb
+++ b/app/views/shared/_plan_card.html.erb
@@ -126,24 +126,26 @@
       <% end %>
     </div>
     <% if _plan %>
+      <%# 編集リンク（スタンドアロン + 所有者のみ表示、CSSで制御） %>
       <% if _can_edit %>
         <%= link_to edit_plan_path(_plan), class: "plan-card__detail-link plan-card__detail-link--edit", data: { turbo_frame: "_top" }, aria: { label: "プランを編集" } do %>
           編集する
           <i class="bi bi-pencil" aria-hidden="true"></i>
         <% end %>
-      <% else %>
-        <%# ルートプレビューボタン（ナビバー内で表示） %>
-        <button type="button"
-                class="plan-card__detail-link plan-card__detail-link--preview"
-                aria-label="ルートをプレビュー"
-                data-controller="community-tab--plan-preview"
-                data-community-tab--plan-preview-spots-value="<%= plan_preview_spots_json(_spots) %>"
-                data-community-tab--plan-preview-polylines-value="<%= plan_preview_polylines_json(_plan) %>"
-                data-action="click->community-tab--plan-preview#show">
-          <i class="bi bi-share" aria-hidden="true"></i>
-          ルート
-        </button>
-        <%# 地図で見るリンク（スタンドアロンページで表示） %>
+      <% end %>
+      <%# ルートプレビューボタン（ナビバー内で表示、CSSで制御） %>
+      <button type="button"
+              class="plan-card__detail-link plan-card__detail-link--preview"
+              aria-label="ルートをプレビュー"
+              data-controller="community-tab--plan-preview"
+              data-community-tab--plan-preview-spots-value="<%= plan_preview_spots_json(_spots) %>"
+              data-community-tab--plan-preview-polylines-value="<%= plan_preview_polylines_json(_plan) %>"
+              data-action="click->community-tab--plan-preview#show">
+        <i class="bi bi-share" aria-hidden="true"></i>
+        ルート
+      </button>
+      <%# 地図で見るリンク（スタンドアロン + 非所有者のみ表示、CSSで制御） %>
+      <% unless _can_edit %>
         <%= link_to plan_path(_plan), class: "plan-card__detail-link plan-card__detail-link--view", data: { turbo_frame: "_top" }, aria: { label: "プラン詳細を見る" } do %>
           地図で見る
           <i class="bi bi-chevron-right" aria-hidden="true"></i>


### PR DESCRIPTION
## 概要
地図画面（ナビバー内）のプランカードでは、自分が作成したプランでも削除ボタンと編集ボタンを表示せず、ルートボタンのみ表示するように修正。

## 作業項目
- ルートボタンを常に描画するようERBを修正
- ナビバー内では削除・編集を非表示にするCSSを追加

## 変更ファイル
- `app/views/shared/_plan_card.html.erb`: ルートボタンを常に描画、編集/地図で見るは所有者で分岐
- `app/assets/stylesheets/plans/cards/_plan_card.scss`: ナビバー内で削除・編集を非表示

## 検証
### 手動テスト
- [x] ナビバー内で自分のプランにルートボタンが表示される
- [x] ナビバー内で自分のプランに削除・編集ボタンが表示されない
- [x] スタンドアロンページで自分のプランに削除・編集ボタンが表示される

### 自動テスト
- 表示のみの変更のためテスト追加なし

## 関連issue
close #565