### PR TITLE
fix: 円描画/プレビュー機能の不具合修正

### DIFF
--- a/app/javascript/controllers/community_tab/plan_preview_controller.js
+++ b/app/javascript/controllers/community_tab/plan_preview_controller.js
@@ -4,7 +4,7 @@ import {
   setCommunityPreviewMarkers,
   setCommunityPreviewPolylines,
   clearCommunityPreview,
-  clearSuggestionMarkers,
+  clearSuggestionAll,
   getPlanSpotMarkers,
 } from "map/state"
 import { showInfoWindowWithFrame, closeInfoWindow } from "map/infowindow"
@@ -76,7 +76,7 @@ export default class extends Controller {
 
   hide() {
     clearCommunityPreview()
-    clearSuggestionMarkers()  // 円エリアもクリア
+    clearSuggestionAll()  // 円エリアもクリア
     hideCloseButton()
 
     // search_filters_controller に円クリアを通知

--- a/app/javascript/controllers/community_tab/search_filters_controller.js
+++ b/app/javascript/controllers/community_tab/search_filters_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { clearSuggestionMarkers } from "map/state"
+import { clearSuggestionAll, getCommunityPreviewMarkers } from "map/state"
 import { fitBoundsWithPadding } from "map/visual_center"
 
 // ================================================================
@@ -209,11 +209,14 @@ export default class extends Controller {
   // 「エリア選択を解除」ボタンクリック
   clearCircle() {
     // 地図上の円をクリア
-    clearSuggestionMarkers()
+    clearSuggestionAll()
 
-    // 地図上の削除ボタンを非表示
+    // コミュニティプレビューがない場合のみ削除ボタンを非表示
+    // （プレビュー表示中はボタンを残す）
     const clearBtn = document.getElementById("community-preview-close")
-    if (clearBtn) clearBtn.hidden = true
+    if (clearBtn && getCommunityPreviewMarkers().length === 0) {
+      clearBtn.hidden = true
+    }
 
     this.resetCircleState()
     this.submitForm()

--- a/app/javascript/controllers/ui/area_draw_controller.js
+++ b/app/javascript/controllers/ui/area_draw_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { getMapInstance, setSuggestionAreaCircle, clearSuggestionMarkers } from "map/state"
+import { getMapInstance, setSuggestionAreaCircle, clearSuggestionAll } from "map/state"
 import { closeInfoWindow } from "map/infowindow"
 import { fitBoundsWithPadding } from "map/visual_center"
 
@@ -51,7 +51,7 @@ export default class extends Controller {
     if (!this.map) return
 
     // 既存の提案（円+ピン）をクリア
-    clearSuggestionMarkers()
+    clearSuggestionAll()
     closeInfoWindow()
     const clearBtn = document.getElementById("suggestion-pin-clear")
     if (clearBtn) clearBtn.hidden = true
@@ -420,7 +420,7 @@ export default class extends Controller {
 
   cancel() {
     // 円+ピンをクリア（enterDrawModeで既にクリア済みだが、念のため）
-    clearSuggestionMarkers()
+    clearSuggestionAll()
     const clearBtn = document.getElementById("suggestion-pin-clear")
     if (clearBtn) clearBtn.hidden = true
 

--- a/app/javascript/map/state.js
+++ b/app/javascript/map/state.js
@@ -177,12 +177,17 @@ export const setPopularSpotMarkers = (markers) => {
 };
 
 // --- 提案マーカー ---
-// 全クリア（マーカー + パルス + 円）
+// マーカーのみクリア（円は保持）
 export const clearSuggestionMarkers = () => {
   suggestionMarkers.forEach((m) => m.setMap(null));
   suggestionMarkers = [];
   suggestionOverlays.forEach((o) => o.setMap(null));
   suggestionOverlays = [];
+};
+
+// 全クリア（マーカー + パルス + 円）
+export const clearSuggestionAll = () => {
+  clearSuggestionMarkers();
   suggestionAreaCircles.forEach(c => c.setMap(null));
   suggestionAreaCircles = [];
 };


### PR DESCRIPTION
## 概要
コミュニティタブでの円描画・プレビュー機能に関する不具合を修正。

## 作業項目
- `clearSuggestionMarkers()` と `clearSuggestionAll()` の責務を分離
- プレビュー表示中にエリア選択を解除しても削除ボタンが消えないよう修正
- スクロール制御の改善

## 変更ファイル
- `app/javascript/map/state.js`: マーカー/円のクリア関数を分離
- `app/javascript/controllers/community_tab/search_filters_controller.js`: プレビューマーカー存在チェック追加
- `app/javascript/controllers/community_tab/plan_preview_controller.js`: クリア関数の使い分け
- `app/javascript/controllers/community_tab/scroll_controller.js`: スクロール制御改善
- `app/javascript/controllers/ui/area_draw_controller.js`: クリア関数の使い分け

## 検証
### 手動テスト
- [x] 提案タブで円が正しく描画される
- [x] プレビュー表示中にエリア解除しても削除ボタンが残る
- [x] コミュニティタブのスクロールが正常に動作する

## 関連issue
close #569