### PR TITLE
fix: AI提案タブの不具合修正（フォームリセット・スロット数制限・ジャンル重複防止）

### DIFF
--- a/app/javascript/controllers/suggestion_tab/condition_modal_controller.js
+++ b/app/javascript/controllers/suggestion_tab/condition_modal_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { clearSuggestionMarkers } from "map/state"
+import { clearSuggestionAll } from "map/state"
 import { postTurboStream } from "services/navibar_api"
 
 // ================================================================
@@ -46,6 +46,9 @@ export default class extends Controller {
       radius_km: detail.radius_km
     }
 
+    // フォームを初期状態にリセット
+    this.#resetForm()
+
     this.titleTarget.textContent = "プラン条件を設定"
     this.areaInfoTarget.textContent = `選択エリア（半径 ${this.areaData.radius_km.toFixed(1)} km）`
     this.#showModal()
@@ -58,7 +61,7 @@ export default class extends Controller {
 
   // キャンセル時は円も消去
   cancel() {
-    clearSuggestionMarkers()
+    clearSuggestionAll()
     this.close()
   }
 
@@ -124,6 +127,23 @@ export default class extends Controller {
   #showModal() {
     this.element.hidden = false
     document.body.style.overflow = "hidden"
+  }
+
+  // フォームを初期状態にリセット
+  #resetForm() {
+    // スポット数を3にリセット
+    this.spotCountTarget.value = "3"
+
+    // スロットを初期状態にリセット
+    this.slotTargets.forEach((slot, i) => {
+      slot.hidden = i >= 3
+    })
+    this.slotBtnTargets.forEach(btn => {
+      btn.querySelector("span").textContent = "おまかせ"
+    })
+    this.slotInputTargets.forEach(input => {
+      input.value = ""
+    })
   }
 
   async #submitPlanMode() {

--- a/app/javascript/controllers/suggestion_tab/controller.js
+++ b/app/javascript/controllers/suggestion_tab/controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { clearSuggestionMarkers } from "map/state"
+import { clearSuggestionAll } from "map/state"
 import { closeInfoWindow } from "map/infowindow"
 
 // ================================================================
@@ -66,7 +66,7 @@ export default class extends Controller {
 
   // 会話クリア時に提案マーカーもクリア
   clearConversation() {
-    clearSuggestionMarkers()
+    clearSuggestionAll()
     closeInfoWindow()
     // 提案ピンクリアボタンを非表示に
     const pinClearBtn = document.getElementById("suggestion-pin-clear")

--- a/app/javascript/controllers/suggestion_tab/mode_controller.js
+++ b/app/javascript/controllers/suggestion_tab/mode_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { getMapInstance, clearSuggestionMarkers, setSuggestionAreaCircle } from "map/state"
+import { getMapInstance, clearSuggestionAll, setSuggestionAreaCircle } from "map/state"
 import { fitBoundsWithPadding } from "map/visual_center"
 import { postTurboStream } from "services/navibar_api"
 
@@ -33,7 +33,7 @@ export default class extends Controller {
 
   // エリアを選び直す（既存条件保持）
   reselectArea() {
-    clearSuggestionMarkers()
+    clearSuggestionAll()
     this.#dispatchAreaDraw(this.modeValue, {
       condition: this.conditionValue
     })
@@ -41,7 +41,7 @@ export default class extends Controller {
 
   // 条件を変更（同じエリアで再度モーダルを開く）
   changeCondition() {
-    clearSuggestionMarkers()
+    clearSuggestionAll()
     const area = this.areaValue || {}
 
     // 同じエリアで円を再描画してズーム

--- a/app/javascript/controllers/suggestion_tab/pin_clear_controller.js
+++ b/app/javascript/controllers/suggestion_tab/pin_clear_controller.js
@@ -4,12 +4,12 @@
 // ================================================================
 
 import { Controller } from "@hotwired/stimulus"
-import { clearSuggestionMarkers } from "map/state"
+import { clearSuggestionAll } from "map/state"
 import { closeInfoWindow } from "map/infowindow"
 
 export default class extends Controller {
   clear() {
-    clearSuggestionMarkers()
+    clearSuggestionAll()
     closeInfoWindow()
     this.element.hidden = true
   }

--- a/app/javascript/controllers/suggestion_tab/plan_adopt_controller.js
+++ b/app/javascript/controllers/suggestion_tab/plan_adopt_controller.js
@@ -11,6 +11,7 @@ import { Controller } from "@hotwired/stimulus"
 import {
   getMapInstance,
   clearSuggestionMarkers,
+  clearSuggestionAll,
   addSuggestionMarker,
 } from "map/state"
 import { showInfoWindowWithFrame, closeInfoWindow } from "map/infowindow"
@@ -35,6 +36,7 @@ export default class extends Controller {
 
   // 自動でピン表示
   #autoLoadSpots() {
+    clearSuggestionMarkers()  // 前回の提案マーカーをクリア（円は保持）
     this._resolvedSpots = this.#resolveSpots()
     this.#showMarkersOnMap()
   }
@@ -61,7 +63,7 @@ export default class extends Controller {
       btn.classList.add("suggestion-plan-card__adopt-btn--adopted")
 
       // 提案ピンをクリア
-      clearSuggestionMarkers()
+      clearSuggestionAll()
       closeInfoWindow()
       const clearBtn = document.getElementById("suggestion-pin-clear")
       if (clearBtn) clearBtn.hidden = true

--- a/app/models/suggestion/generator.rb
+++ b/app/models/suggestion/generator.rb
@@ -78,8 +78,10 @@ class Suggestion::Generator
     # @return [Array<Hash>] 選出されたスポット（descriptionを含む）
     def select_plan_spots(ai_response, all_spots, slot_sizes)
       picks = ai_response[:picks] || []
+      slot_count = slot_sizes.size
 
-      selected = picks.filter_map do |pick|
+      # スロット数を超える選出を防止
+      selected = picks.first(slot_count).filter_map do |pick|
         number = pick[:n]
         description = pick[:d]
         spot = all_spots[number - 1]

--- a/app/models/suggestion/spot_finder.rb
+++ b/app/models/suggestion/spot_finder.rb
@@ -56,9 +56,15 @@ genre_ids_to_try = [ preferred_id, *queue ].compact
       queue.delete(genre_id)
       used_spot_ids.merge(candidates.map { |c| c[:id] })
 
-      # 使用した主要ジャンルを記録（キュー選択時もnilフォールバック時も同様）
-      primary_genre_id = extract_primary_genre_id(candidates.first)
-      used_genre_ids.add(primary_genre_id) if primary_genre_id
+      # 使用したジャンルを記録
+      # - 特定ジャンル検索時: そのジャンルIDを記録
+      # - nilフォールバック時: 結果の主要ジャンルを記録
+      if genre_id
+        used_genre_ids.add(genre_id)
+      else
+        primary_genre_id = extract_primary_genre_id(candidates.first)
+        used_genre_ids.add(primary_genre_id) if primary_genre_id
+      end
 
       genre = genre_id ? Genre.find_by(id: genre_id) : nil
       return { genre_name: genre&.name || "おすすめ", candidates: candidates }


### PR DESCRIPTION
## 概要
AI提案タブの複数の不具合を修正。

## 作業項目
- 条件モーダルのフォームリセット機能追加
- `clearSuggestionMarkers` と `clearSuggestionAll` の使い分け
- AIが返すスポット数をスロット数で制限
- ジャンル重複防止のロジック修正

## 変更ファイル
### JavaScript
- `app/javascript/controllers/suggestion_tab/condition_modal_controller.js`: フォームリセット追加
- `app/javascript/controllers/suggestion_tab/controller.js`: クリア関数修正
- `app/javascript/controllers/suggestion_tab/mode_controller.js`: クリア関数修正
- `app/javascript/controllers/suggestion_tab/pin_clear_controller.js`: クリア関数修正
- `app/javascript/controllers/suggestion_tab/plan_adopt_controller.js`: 採用時/提案時のクリア使い分け

### Ruby
- `app/models/suggestion/generator.rb`: `picks.first(slot_count)` でスポット数制限
- `app/models/suggestion/spot_finder.rb`: `used_genre_ids` の記録ロジック修正

## 検証
### 手動テスト
- [x] 条件変更時にフォームが初期化される
- [x] エリア再選択時に円がクリアされる
- [x] 3スロット指定時に3スポットのみ表示される
- [x] ジャンル重複なく多様なスポットが提案される

## 関連issue
close #570