### PR TITLE
fix: OGPメタタグのドメインを drivepeek.app に更新

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,8 +10,8 @@
     <meta property="og:title" content="DrivePeek - ドライブプラン作成アプリ">
     <meta property="og:description" content="3つの探し方で見つけて、計画、そのまま出発。">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://drivepeek.onrender.com/">
-    <meta property="og:image" content="https://drivepeek.onrender.com/ogp.png">
+    <meta property="og:url" content="https://drivepeek.app/">
+    <meta property="og:image" content="https://drivepeek.app/ogp.png">
     <meta property="og:site_name" content="DrivePeek">
     <meta property="og:locale" content="ja_JP">
 
@@ -19,7 +19,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="DrivePeek - ドライブプラン作成アプリ">
     <meta name="twitter:description" content="3つの探し方で見つけて、計画、そのまま出発。">
-    <meta name="twitter:image" content="https://drivepeek.onrender.com/ogp.png">
+    <meta name="twitter:image" content="https://drivepeek.app/ogp.png">
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="icon" href="/favicon-32x32.png" type="image/png" sizes="32x32">
     <link rel="icon" href="/favicon-16x16.png" type="image/png" sizes="16x16">


### PR DESCRIPTION
## 概要
OGPメタタグのURLが旧ドメイン（drivepeek.onrender.com）のままになっていたため、SNS共有時のプレビューが正しく表示されなかった問題を修正。

## 作業項目
- `og:url` を `https://drivepeek.app/` に更新
- `og:image` を `https://drivepeek.app/ogp.png` に更新
- `twitter:image` を `https://drivepeek.app/ogp.png` に更新

## 変更ファイル
- `app/views/layouts/application.html.erb`: OGP/Twitterカードのメタタグを新ドメインに変更

## 検証
### 手動テスト
- [x] Mattermost等でURLを貼り付けてプレビューが表示されること
- [x] Twitter Card Validatorで正しく表示されること

### 自動テスト
- 該当なし（静的なメタタグ変更のみ）

## 関連issue
close #577