### PR TITLE
検索・人気スポット検索UIの改善

### DIFF
--- a/app/assets/stylesheets/map/_popular_spots.scss
+++ b/app/assets/stylesheets/map/_popular_spots.scss
@@ -53,7 +53,6 @@
     align-items: center;
     justify-content: space-between;
     padding: 16px 20px;
-    border-bottom: 1px solid #eee;
   }
 
   &__title {
@@ -80,6 +79,18 @@
     i {
       font-size: 16px;
       color: #666;
+    }
+  }
+
+  &__description {
+    margin: 0;
+    padding: 0 20px 12px;
+    font-size: 13px;
+    line-height: 1.6;
+    color: #666;
+
+    i {
+      color: #F97316;
     }
   }
 

--- a/app/views/shared/_map_header_bar.html.erb
+++ b/app/views/shared/_map_header_bar.html.erb
@@ -11,7 +11,7 @@
       <input
         id="places-search-box"
         type="text"
-        placeholder="      検索"
+        placeholder="      GoogleMap で検索"
         class="map-header-bar__search-input"
       >
     </div>
@@ -21,7 +21,7 @@
       <button type="button"
               class="map-header-bar__pill-left"
               data-action="click->ui--popular-spots#openModal"
-              title="話題のスポットを探す">
+              title="人気スポット検索 - ジャンル選択">
         <i class="bi bi-sliders"></i>
       </button>
       <button type="button"
@@ -88,13 +88,17 @@
         <div class="popular-spots-modal__handle-bar"></div>
       </div>
       <div class="popular-spots-modal__header">
-        <h3 class="popular-spots-modal__title">話題のスポットを探す</h3>
+        <h3 class="popular-spots-modal__title">人気スポット検索 - ジャンル選択</h3>
         <button type="button"
                 class="popular-spots-modal__close-btn"
                 data-action="click->ui--popular-spots#closeModal">
           <i class="bi bi-x-lg"></i>
         </button>
       </div>
+      <p class="popular-spots-modal__description">
+        地図を好きな場所に移動して<i class="bi bi-fire"></i>ボタンを押すと、ここで選択したジャンルで人気スポットを再検索できます。<br>
+        ※未選択時は全ジャンルで検索
+      </p>
 
       <div class="selection-list popular-spots-modal__list">
         <% genres_by_category.each do |category, groups| %>


### PR DESCRIPTION
## 概要
地図ヘッダーバーの検索とジャンル選択モーダルのUIを改善して、機能の役割を明確にしました。

## 作業項目
- 検索プレースホルダーを「GoogleMap で検索」に変更
- 人気スポットモーダルのタイトルを「人気スポット検索 - ジャンル選択」に変更
- 説明文追加（🔥ボタンの使い方 + 未選択時は全ジャンル検索）
- ヘッダーの区切り線を削除
- ボタンのtitle属性を更新

## 変更ファイル
- `app/views/shared/_map_header_bar.html.erb`: プレースホルダー・タイトル・説明文変更
- `app/assets/stylesheets/map/_popular_spots.scss`: 説明文スタイル追加、ヘッダー区切り線削除

## 検証
### 手動テスト
- [x] 検索プレースホルダーが「GoogleMap で検索」と表示される
- [x] ジャンル選択モーダルのタイトル・説明文が正しく表示される
- [x] 🔥ボタンで人気スポット検索が動作する

### 自動テスト
- CSS build: 成功

## 関連issue
close #590