### PR TITLE
feat: Google APIキーをフロントエンド/バックエンドで分離 (#597)

### DIFF
--- a/app/clients/google_api.rb
+++ b/app/clients/google_api.rb
@@ -29,10 +29,11 @@ module GoogleApi
       JSON.parse(response.body)
     end
 
-    # Google Maps API キーを取得
+    # Google API キーを取得（バックエンド用: Geocoding, Directions）
+    # フロントエンド用は GOOGLE_FRONTEND_API_KEY を使用（application.html.erb）
     # @return [String, nil]
     def api_key
-      ENV["GOOGLE_MAPS_API_KEY"]
+      ENV["GOOGLE_BACKEND_API_KEY"]
     end
 
     # 住所を正規化（国名・郵便番号を除去）

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,12 +35,12 @@
 
     <%= javascript_importmap_tags %>
 
-    <% if ENV["GOOGLE_MAPS_API_KEY"].present? %>
+    <% if ENV["GOOGLE_FRONTEND_API_KEY"].present? %>
       <script
         id="google-maps-script"
         data-turbo-permanent
         async
-        src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&libraries=places,geometry">
+        src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_FRONTEND_API_KEY'] %>&libraries=places,geometry">
       </script>
     <% end %>
   </head>

--- a/spec/clients/google_api_spec.rb
+++ b/spec/clients/google_api_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe GoogleApi do
   describe ".api_key" do
-    it "GOOGLE_MAPS_API_KEYを返す" do
+    it "GOOGLE_BACKEND_API_KEYを返す" do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("GOOGLE_MAPS_API_KEY").and_return("test-api-key")
+      allow(ENV).to receive(:[]).with("GOOGLE_BACKEND_API_KEY").and_return("test-api-key")
 
       expect(GoogleApi.api_key).to eq("test-api-key")
     end


### PR DESCRIPTION
## 概要
Google APIキーをフロントエンド用とバックエンド用に分離し、セキュリティを向上させる。

## 作業項目
- 環境変数名を `GOOGLE_FRONTEND_API_KEY` / `GOOGLE_BACKEND_API_KEY` に変更
- フロントエンド: リファラー制限（Maps JavaScript API, Places API）
- バックエンド: API制限のみ（Geocoding API, Directions API）

## 変更ファイル
- `app/clients/google_api.rb`: `GOOGLE_BACKEND_API_KEY` を使用
- `app/views/layouts/application.html.erb`: `GOOGLE_FRONTEND_API_KEY` を使用
- `spec/clients/google_api_spec.rb`: テスト修正

## 検証
### 手動テスト
- [ ] ローカルで環境変数設定後、地図表示・検索ボックスが動作する
- [ ] 出発地点/帰宅地点の住所編集が動作する
- [ ] Renderデプロイ後、本番環境で動作確認

### 自動テスト
- RSpec: 674 examples, 0 failures
- Coverage: 98.06%

## 関連issue
close #597