### PR TITLE
feat: 道の駅・SA/PAジャンルを分割

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,7 +24,8 @@ GENRES = [
   # ==========================================
   # 買う
   # ==========================================
-  { name: "道の駅・SA/PA", slug: "roadside_station", category: "買う", visible: true, emoji: "🚗" },
+  { name: "道の駅", slug: "roadside_station", category: "買う", visible: true, emoji: "🚗" },
+  { name: "SA/PA", slug: "service_area", category: "買う", visible: true, emoji: "🚗" },
   # ショッピング（親ジャンル・子ジャンルは非表示）
   { name: "ショッピング", slug: "shopping", category: "買う", visible: true, emoji: "🛍️" },
   { name: "雑貨屋", slug: "variety_store", category: "買う", visible: false, parent_slug: "shopping", emoji: "🛍️" },


### PR DESCRIPTION
## 概要
「道の駅・SA/PA」ジャンルを「道の駅」と「SA/PA」に分割しました。AI提案の優先キューは「道の駅」のみを対象とし、SA/PAは除外されます。

## 作業項目
- seeds.rbの「道の駅・SA/PA」を「道の駅」に名称変更
- 新ジャンル「SA/PA」(service_area)を追加

## 変更ファイル
- `db/seeds.rb`: ジャンル定義の分割

## 検証
### 手動テスト
- [x] 道の駅ジャンルのスポットが正しく表示される
- [x] SA/PAジャンルのスポットが正しく表示される
- [x] AI提案で道の駅が優先キューに含まれる

### 自動テスト
- RSpec: 32 examples, 0 failures
- 関連するsuggestionテストが全て通過

## 関連issue
close #617