### PR TITLE
fix: エリア描画モード時に検索ボックス・人気スポットボタンを非表示

### DIFF
--- a/app/assets/stylesheets/shared/_area_draw.scss
+++ b/app/assets/stylesheets/shared/_area_draw.scss
@@ -14,7 +14,7 @@
 
 /* エリア描画モード（body クラスで一括制御） */
 body.area-draw-active {
-  .map-search-box,
+  .map-header-bar,
   .hamburger,
   .map-floating-buttons,
   .map-bottom-actions {


### PR DESCRIPTION
## 概要
エリア描画モード時に、地図上のGoogle検索ボックスと人気スポット表示ボタンも非表示にするようにしました。

## 作業項目
- `.map-search-box`（未使用クラス）を`.map-header-bar`に置き換え
- 検索バー、ピルボタン（🎚️|🔥）がエリア描画中に非表示になる

## 変更ファイル
- `app/assets/stylesheets/shared/_area_draw.scss`: 非表示対象クラスの更新

## 検証
### 手動テスト
- [ ] AI提案タブでエリア描画モードに入ると検索ボックスが非表示になる
- [ ] エリア描画モード時に人気スポットボタン（🎚️|🔥）が非表示になる
- [ ] エリア描画キャンセル後に検索ボックス・ボタンが再表示される

### 自動テスト
- CSSのみの変更のため、RSpecテストへの影響なし

## 関連issue
close #621