### PR TITLE
fix: マイルートタブのスポットクリック時にInfoWindowのボタンが表示されない

### DIFF
--- a/app/javascript/controllers/ui/navibar_marker_button_controller.js
+++ b/app/javascript/controllers/ui/navibar_marker_button_controller.js
@@ -36,7 +36,7 @@ export default class extends Controller {
     // DOMからスポット情報を取得
     const spotId = spotBlock.dataset.spotId
     const placeId = spotBlock.dataset.placeId
-    const planId = spotBlock.dataset["planTab-SpotDeletePlanIdValue"]
+    const planId = spotBlock.dataset.planId
     const planSpotId = spotBlock.dataset.planSpotId
     const nameEl = spotBlock.querySelector(".spot-name")
     const addressEl = spotBlock.querySelector(".spot-address")


### PR DESCRIPTION
## 概要
プラン作成画面のマイルートタブで、スポット番号アイコンをクリックした時のInfoWindowにスポット削除ボタンが表示されないバグを修正しました。

## 作業項目
- `navibar_marker_button_controller.js` で `planId` の取得に間違ったデータ属性名を使用していた問題を修正

## 変更ファイル
- `app/javascript/controllers/ui/navibar_marker_button_controller.js`: データ属性名を修正

## 検証
### 手動テスト
- [ ] マイルートタブのスポット番号アイコンをクリックするとInfoWindowが表示される
- [ ] InfoWindowに「プランから削除」ボタンが表示される
- [ ] 削除ボタンをクリックするとスポットが削除される

### 自動テスト
- RSpec: 651 examples, 0 failures
- Coverage: 98.0%

## 関連issue
close #636